### PR TITLE
Update kernel configurations of gtc-conv-fwd

### DIFF
--- a/config/igemm_fwd_gtc_gfx908.config
+++ b/config/igemm_fwd_gtc_gfx908.config
@@ -3,396 +3,6 @@ arch = 'gfx908'
 code_object = 'cov3'
 mode = 'flat'
 
-#--------------------------- 256x128
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 128
-# gemm_k_per_block         = 16
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 32
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  2,  1,  4]     # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1,  8,  1, 32]    # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 16
-# nxe                      = 0
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  2,  4]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1, 16,  1, 16]    # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 16
-nxe                      = 0
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  2,  4]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  16, 1, 16]     # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 4
-nxe                      = 0
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  8,  1,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  2,  1,128]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 1
-nxe                      = 0
-
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  8,  1]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1, 16,  1, 16]     # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 16
-nxe                      = 1
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  8,  1]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  16,  1, 16]    # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 4
-nxe                      = 1
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 1
-nxe                      = 1
-
-# gemm_k=8
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 8
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  2,  1,128]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  1,  4]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  8,  1, 32]     # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 16
-nxe                      = 0
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 8
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  2,  1,128]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  1,  4]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  8,  1, 32]    # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 4
-nxe                      = 0
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 8
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  2,  1,128]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  2,  1,128]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 1
-nxe                      = 0
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 8
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  2,  1,128]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  4,  1]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  8,  1, 32]     # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 16
-nxe                      = 1
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 8
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]     # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  2,  1,128]     # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  4,  1]     # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  8,  1, 32]    # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 4
-nxe                      = 1
-
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 8
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  2,  1,128]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 1
-nxe                      = 1
-
-
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 128
-# gemm_k_per_block         = 16
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 32
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 1                    
-# nxe                      = 1
-
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 128
-# gemm_k_per_block         = 16
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 32
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 1                    
-# nxe                      = 0
-# # gemm_n_unmerge_cluster = 1
-
-
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 128
-# gemm_k_per_block         = 16
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 32
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  8,  1,  1]      # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 1                    
-# nxe                      = 0
-# # gemm_n_unmerge_cluster = 1
-
-
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 128
-# gemm_k_per_block         = 16
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 32
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 1
-# nxe                      = 0
-# # gemm_n_unmerge_cluster = 1
-
-
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 128
-# gemm_k_per_block         = 16
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 32
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 1
-# nxe                      = 0
-
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 64
-# gemm_k_per_block         = 32
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 16
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  8,  1]      # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1, 32,  1,  8]      # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 1                    
-# nxe                      = 0
-
-
-# [igemm_fwd_gtc]
-# gemm_m_per_block         = 256
-# gemm_n_per_block         = 128
-# gemm_k_per_block         = 16
-# wave_tile_m              = 64
-# wave_step_m              = 1
-# wave_repeat_m            = 2
-# wave_tile_n              = 32
-# wave_step_n              = 1
-# wave_repeat_n            = 2
-# tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-# tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-# tensor_b_thread_lengths  = [1,  4,  1,  2]      # C0xC1ExN0xN1B
-# tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
-# direction                = 'fwd'
-# precision                = 'fp32'
-# nxb                      = 4
-# nxe                      = 0
 
 #--------------------------- 128x256
 [igemm_fwd_gtc]
@@ -405,15 +15,16 @@ wave_repeat_m            = 2
 wave_tile_n              = 64
 wave_step_n              = 1
 wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 1                    
-nxe                      = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
 
+#--------------------------- 128x256
 [igemm_fwd_gtc]
 gemm_m_per_block         = 128
 gemm_n_per_block         = 256
@@ -424,15 +35,1094 @@ wave_repeat_m            = 2
 wave_tile_n              = 64
 wave_step_n              = 1
 wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  4,  4]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 16
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
 nxe                      = 0
 
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 1, 1, 256]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 1, 1, 256]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 1, 1, 256]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 1, 1, 256]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
 
 #--------------------------- 128x128
 [igemm_fwd_gtc]
@@ -445,15 +1135,314 @@ wave_repeat_m            = 2
 wave_tile_n              = 32
 wave_step_n              = 1
 wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
-nxb                      = 1                    
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
 nxe                      = 1
 
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
 
 #--------------------------- 256x64
 [igemm_fwd_gtc]
@@ -466,32 +1455,4492 @@ wave_repeat_m            = 2
 wave_tile_n              = 16
 wave_step_n              = 1
 wave_repeat_n            = 2
-tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
 nxb                      = 1
 nxe                      = 1
 
-#--------------------------- 32x16
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
 [igemm_fwd_gtc]
 gemm_m_per_block         = 32
-gemm_n_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 32
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 2]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 16, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
 gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 4
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 32
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 4]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 32
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 4]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 4
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 32
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 16, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 64
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 4]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 16, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
 wave_tile_m              = 32
 wave_step_m              = 1
 wave_repeat_m            = 1
 wave_tile_n              = 8
 wave_step_n              = 2
 wave_repeat_n            = 1
-tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  2,  1, 32]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 2, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
 nxb                      = 1
 nxe                      = 1
 
@@ -499,18 +5948,1338 @@ nxe                      = 1
 [igemm_fwd_gtc]
 gemm_m_per_block         = 16
 gemm_n_per_block         = 32
-gemm_k_per_block         = 4
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
 wave_tile_m              = 8
 wave_step_m              = 2
 wave_repeat_m            = 1
 wave_tile_n              = 32
 wave_step_n              = 1
 wave_repeat_n            = 1
-tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
-tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
-tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
-tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
-direction                = 'fwd'
-precision                = 'fp32'
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 16, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 1, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 64
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 32
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 16
+gemm_k_per_block         = 4
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 16
+nxe                      = 0
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+tensor_a_thread_lengths  = [1, 1, 16, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 4]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp32"
 nxb                      = 1
 nxe                      = 1


### PR DESCRIPTION
Update to a complete list of  kernel configurations for gtc-conv-fwd,  which is
  1) well validated using both the igemm-generator driver and MIOpenDriver
  2) the same as what is submitted to MIOpen by PR.462 
  3) covering the mask-rcnn convolutions