### PR TITLE
Odd image size

### DIFF
--- a/driver/conv_driver.cpp
+++ b/driver/conv_driver.cpp
@@ -428,7 +428,7 @@ int main(int argc, char **argv) {
     if (need_fwd){
         result_t fastest_result_fwd;
         fastest_result_fwd.duration_ms = FLT_MAX;
-        int fastest_id = 0;
+        int fastest_id = -1;
         float *device_output_to_host = NULL;
         if (need_verify) {
             // gen rand
@@ -492,7 +492,10 @@ int main(int argc, char **argv) {
         }
         if(log_fastest_config){
             dump_arg(&conv_args);
-            printf("  fastest: [%d]%s, cost:%.3fms, tflops:%.3f(%.2f%%)\n",
+            if(fastest_id == -1)
+                printf("  fastest: no suitable kernel\n");
+            else
+                printf("  fastest: [%d]%s, cost:%.3fms, tflops:%.3f(%.2f%%)\n",
                     fastest_id,
                     fastest_result_fwd.kernel_name.c_str(),
                     fastest_result_fwd.duration_ms,
@@ -507,7 +510,7 @@ int main(int argc, char **argv) {
         float *device_input_to_host = NULL;
         result_t fastest_result_bwd;
         fastest_result_bwd.duration_ms = FLT_MAX;
-        int fastest_id;
+        int fastest_id = -1;
         if (need_verify) {
             // gen rand
             gen_rand_vector<float, float>(host_output, n * k * ho * wo, 0.0, 1.0);
@@ -590,7 +593,10 @@ int main(int argc, char **argv) {
         }
         if(log_fastest_config){
             dump_arg(&conv_args);
-            printf("  fastest: [%d]%s, cost:%.3fms, tflops:%.3f(%.2f%%)\n",
+            if(fastest_id == -1)
+                printf("  fastest: no suitable kernel\n");
+            else
+                printf("  fastest: [%d]%s, cost:%.3fms, tflops:%.3f(%.2f%%)\n",
                     fastest_id,
                     fastest_result_bwd.kernel_name.c_str(),
                     fastest_result_bwd.duration_ms,

--- a/driver/conv_driver.cpp
+++ b/driver/conv_driver.cpp
@@ -43,7 +43,7 @@
 #endif
 
 #ifndef USE_MAGIC_DIV
-#define USE_MAGIC_DIV 1
+#define USE_MAGIC_DIV 0
 #endif
 
 #ifndef USE_SOURCE_ACCESS_ENCODING_KERNEL_NAME

--- a/driver/igemm_bwd_gtc_driver.h
+++ b/driver/igemm_bwd_gtc_driver.h
@@ -247,14 +247,11 @@ public:
         int w_tilda_slice = w_tilda_right - w_tilda_left;
 
         int gemm_m = c;
-
-        int gemm_n = n * h_tilda_slice * w_tilda_slice;
-
         int nxe = tunable->nxe;
         int nxb = tunable->nxb;
         int b = h_tilda_slice * w_tilda_slice;
         b = (nxe == 0) ? (b) : ((b + nxb - 1) / nxb) * nxb;   // pad to nxb modulo when nxe != 0
-        gemm_n = n * b;
+        int gemm_n = n * b;
 
         int grid_size = utility_integer_divide_ceil(gemm_m, gemm_m_per_block) *
                                     utility_integer_divide_ceil(gemm_n, gemm_n_per_block);
@@ -322,8 +319,12 @@ public:
         int num_of_gemm = y_tilda * x_tilda;
 
         int gemm_m = c;
-        int gemm_n = n * h_tilda_slice * w_tilda_slice;
-/*
+        int nxe = tunable->nxe;
+        int nxb = tunable->nxb;
+        int b = h_tilda_slice * w_tilda_slice;
+        b = (nxe == 0) ? (b) : ((b + nxb - 1) / nxb) * nxb;   // pad to nxb modulo when nxe != 0
+        int gemm_n = n * b;
+
         if((gemm_n%gemm_n_per_block!=0)||(gemm_m%gemm_m_per_block!=0)){
             // printf("tunable_is_valid false:: gemm_n is %d, gemm_n_per_block is %d, gemm_m is %d, gemm_m_per_block is %d\n", gemm_n,gemm_n_per_block,gemm_m,gemm_m_per_block);
             return false;
@@ -338,10 +339,9 @@ public:
             // printf("tunable_is_valid false: n%(gemm_n_per_block/tunable->nxb)!=0, gemm_n_per_block is %d, tunable->nxb is %d\n", gemm_n_per_block, tunable->nxb);
             return false;
         }
-        if( (h_tilda_slice * w_tilda_slice) % tunable->nxb != 0){
+        if( (tunable->nxe == 0)&& ((h_tilda_slice * w_tilda_slice) % tunable->nxb != 0) ){
             return false;
         }
-*/
         bool gemm_k_valid = true;
         for(int gemm_id = 0; gemm_id < num_of_gemm; gemm_id++){
             int i_y_tilda = gemm_id / x_tilda;
@@ -467,7 +467,7 @@ public:
 
         hipFunction_t kernel_func;
         std::string kernel_name = get_kernel_name(tunable);
-        printf("kernel:%s\n, block:%d, grid:%d\n", kernel_name.c_str(), block_size, grid_size);
+        //printf("kernel:%s\n, block:%d, grid:%d\n", kernel_name.c_str(), block_size, grid_size);
         HIP_CALL(
             hipModuleGetFunction(&kernel_func, module, kernel_name.c_str()));
 

--- a/driver/igemm_bwd_gtc_driver.h
+++ b/driver/igemm_bwd_gtc_driver.h
@@ -247,7 +247,14 @@ public:
         int w_tilda_slice = w_tilda_right - w_tilda_left;
 
         int gemm_m = c;
+
         int gemm_n = n * h_tilda_slice * w_tilda_slice;
+
+        int nxe = tunable->nxe;
+        int nxb = tunable->nxb;
+        int b = h_tilda_slice * w_tilda_slice;
+        b = (nxe == 0) ? (b) : ((b + nxb - 1) / nxb) * nxb;   // pad to nxb modulo when nxe != 0
+        gemm_n = n * b;
 
         int grid_size = utility_integer_divide_ceil(gemm_m, gemm_m_per_block) *
                                     utility_integer_divide_ceil(gemm_n, gemm_n_per_block);
@@ -316,7 +323,7 @@ public:
 
         int gemm_m = c;
         int gemm_n = n * h_tilda_slice * w_tilda_slice;
-
+/*
         if((gemm_n%gemm_n_per_block!=0)||(gemm_m%gemm_m_per_block!=0)){
             // printf("tunable_is_valid false:: gemm_n is %d, gemm_n_per_block is %d, gemm_m is %d, gemm_m_per_block is %d\n", gemm_n,gemm_n_per_block,gemm_m,gemm_m_per_block);
             return false;
@@ -334,7 +341,7 @@ public:
         if( (h_tilda_slice * w_tilda_slice) % tunable->nxb != 0){
             return false;
         }
-
+*/
         bool gemm_k_valid = true;
         for(int gemm_id = 0; gemm_id < num_of_gemm; gemm_id++){
             int i_y_tilda = gemm_id / x_tilda;
@@ -460,7 +467,7 @@ public:
 
         hipFunction_t kernel_func;
         std::string kernel_name = get_kernel_name(tunable);
-        // printf("kernel:%s\n, block:%d, grid:%d\n", kernel_name.c_str(), block_size, grid_size);
+        printf("kernel:%s\n, block:%d, grid:%d\n", kernel_name.c_str(), block_size, grid_size);
         HIP_CALL(
             hipModuleGetFunction(&kernel_func, module, kernel_name.c_str()));
 

--- a/driver/igemm_fwd_gtc_driver.h
+++ b/driver/igemm_fwd_gtc_driver.h
@@ -143,6 +143,7 @@ public:
         int gemm_m = k;
         int gemm_n = n * ho * wo;
 
+        // this also valid considering pad to modulo
         int grid_size = utility_integer_divide_ceil(gemm_m, gemm_m_per_block) *
                                     utility_integer_divide_ceil(gemm_n, gemm_n_per_block);
         return grid_size;
@@ -176,10 +177,17 @@ public:
         int gemm_n = n * ho * wo;
         int gemm_k = c * y * x;
 
-        if((gemm_n % gemm_n_per_block != 0) || (gemm_m % gemm_m_per_block != 0) || (gemm_k % gemm_k_per_block != 0)){
-            // printf("tunable_is_valid false:: gemm_n is %d, gemm_n_per_block is %d, gemm_m is %d, gemm_m_per_block is %d\n", gemm_n,gemm_n_per_block,gemm_m,gemm_m_per_block);
+#if 0
+        // support pad to modulo, no need to check valid
+        if(gemm_n % gemm_n_per_block != 0)
             return false;
-        }
+#endif
+
+        if(gemm_m % gemm_m_per_block != 0)
+            return false;
+
+        if(gemm_k % gemm_k_per_block != 0)
+            return false;
 
         if(gemm_n_per_block % tunable->nxb != 0){
             // printf("tunable_is_valid false: gemm_n_per_block%tunable->nxb!=0, gemm_n_per_block is %d, tunable->nxb is %d\n", gemm_n_per_block, tunable->nxb);
@@ -191,9 +199,11 @@ public:
             return false;
         }
 
-        if( (ho * wo) % tunable->nxb != 0){
+#if 0
+        if((ho * wo) % tunable->nxb != 0){
             return false;
         }
+#endif
 
         if(tunable->nxe == 0){
             if((x!=1)||(y!=1)||(stride_h!=1)||(stride_w!=1)||(dilation_h!=1)||(dilation_w!=1)||(pad_h!=0)||(pad_w!=0)){

--- a/igemm/algo/igemm_base.py
+++ b/igemm/algo/igemm_base.py
@@ -200,7 +200,7 @@ class igemm_gtc_tunable_parameter_t(object):
         # assert type(self.opt_1x1) is bool
         assert self.direction in ('fwd', 'bwd', 'wrw')
         assert self.precision in ('fp32', 'fp16', 'bf16')
-        assert self.nxb in (1,4,8,16,32,64,256)
+        assert self.nxb in (1,4,8,16,32,64,128,256)
         assert self.nxe in (0,1)
 
         # TODO: better specify

--- a/igemm/algo/igemm_bwd_gtc.py
+++ b/igemm/algo/igemm_bwd_gtc.py
@@ -743,6 +743,9 @@ class igemm_bwd_gtc_t(mc_base_t):
                 self.s_stride_dslice_yx    = sym_t("s_stride_dslice_yx"       ,sseq(1))
 
             if outer.tunable.nxe != 0:
+                self.s_dslice_dim_b     = sym_t("s_dslice_dim_b", self.s_stride_dslice_hw.value)
+
+            if outer.tunable.nxe != 0:
                 self.s_out_stride_k_k1         = sym_t("s_out_stride_k_k1"        ,self.s_stride_h.value)
                 self.s_out_stride_k_k0_k1_diff = sym_t("s_out_stride_k_k0_k1_diff",self.s_stride_w.value)
                 self.s_wei_stride_k_k1         = sym_t("s_wei_stride_k_k1"        ,self.s_dilation_h.value)
@@ -1489,6 +1492,12 @@ class igemm_bwd_gtc_t(mc_base_t):
             self._emit(f"s_mul_i32 s[{s.s_wei_stride_k()}],      s[{s.s_c()}],        s[{s.s_wei_stride_c()}]")
             self._emit(f"s_mul_i32 s[{s.s_stride_dslice_hw()}],  s[{s.s_dslice_h()}], s[{s.s_dslice_w()}]")
             self._emit(f"s_mul_i32 s[{s.s_stride_dslice_yx()}],  s[{s.s_dslice_y()}], s[{s.s_dslice_x()}]")
+
+            self._emit(f"; change for padding")
+            self._emit(f"s_add_u32 s[{s.s_tmp()}], {self.tunable.nxb - 1}, s[{s.s_stride_dslice_hw()}]")
+            self._emit(f"s_lshr_b32 s[{s.s_tmp(1)}], s[{s.s_tmp()}], {igemm_log2(self.tunable.nxb)}")
+            self._emit(f"s_lshl_b32 s[{s.s_dslice_dim_b()}], s[{s.s_tmp(1)}], {igemm_log2(self.tunable.nxb)}")
+
             if t_k0 != 1:
                 self._emit(f"s_lshl_b32 s[{s.s_out_stride_k0()}], s[{s.s_out_stride_k()}], {igemm_log2(unmerge_sub_k1)}")
                 self._emit(f"s_lshl_b32 s[{s.s_wei_stride_k0()}], s[{s.s_wei_stride_k()}], {igemm_log2(unmerge_sub_k1)}")
@@ -1551,7 +1560,7 @@ class igemm_bwd_gtc_t(mc_base_t):
         self._emit_empty_line()
         self._emit(f"; gemm_m_per_block:{self.tunable.gemm_m_per_block}, gemm_n_per_block:{self.tunable.gemm_n_per_block}")
         if self.tunable.nxe != 0:
-            self._emit(f"s_mul_i32 s[{s.s_tmp()}], s[{s.s_stride_dslice_hw()}], s[{s.s_n()}]")
+            self._emit(f"s_mul_i32 s[{s.s_tmp()}], s[{s.s_dslice_dim_b()}], s[{s.s_n()}]")
         else:
             self._emit(f"s_mul_i32 s[{s.s_tmp()}], s[{s.s_stride_hw()}], s[{s.s_n()}]")
         self._emit(f"s_lshr_b32 s[0], s[{s.s_tmp()}], {igemm_log2(self.tunable.gemm_n_per_block)}")
@@ -1566,14 +1575,14 @@ class igemm_bwd_gtc_t(mc_base_t):
         if gemm_n_unmerge_cluster == 0:
             if self.tunable.nxe != 0:
                 if unmerge_sub_n1 == 1:
-                    self._emit(f"s_lshr_b32 s[0], s[{s.s_stride_dslice_hw()}], {igemm_log2(n_n1b)} ; total number of n1b")
+                    self._emit(f"s_lshr_b32 s[0], s[{s.s_dslice_dim_b()}], {igemm_log2(n_n1b)} ; total number of n1b")
                 else:
                     if unmerge_sub_n1 == n_n1b:
-                        self._emit(f"s_mov_b32 s[0], s[{s.s_stride_dslice_hw()}] ; total number of n1b")
+                        self._emit(f"s_mov_b32 s[0], s[{s.s_dslice_dim_b()}] ; total number of n1b")
                     else:
                         # self._emit(f"s_lshl_b32 s[{s.s_tmp()}], s[{s.s_stride_dslice_hw()}], {igemm_log2(unmerge_sub_n1)}     ; total number of n1b")
                         # self._emit(f"s_lshr_b32 s[0], s[{s.s_tmp()}], {igemm_log2(n_n1b)}")
-                        self._emit(f"s_lshr_b32 s[0], s[{s.s_stride_dslice_hw()}], {igemm_log2(n_n1b // unmerge_sub_n1)}  ; total number of n1b")
+                        self._emit(f"s_lshr_b32 s[0], s[{s.s_dslice_dim_b()}], {igemm_log2(n_n1b // unmerge_sub_n1)}  ; total number of n1b")
             else:
                 if unmerge_sub_n1 == 1:
                     self._emit(f"s_lshr_b32 s[0], s[{s.s_stride_hw()}], {igemm_log2(n_n1b)} ; total number of n1b")
@@ -1587,7 +1596,7 @@ class igemm_bwd_gtc_t(mc_base_t):
         else:
             if self.tunable.nxe != 0:
                 self._emit(f"s_lshr_b32 s[{s.s_tmp()}], s[{s.s_n()}], {igemm_log2(n_n0)}")
-                self._emit(f"s_mul_i32 s[{s.s_tmp(1)}], s[{s.s_stride_dslice_hw()}], s[{s.s_tmp()}]")
+                self._emit(f"s_mul_i32 s[{s.s_tmp(1)}], s[{s.s_dslice_dim_b()}], s[{s.s_tmp()}]")
                 self._emit(f"s_lshr_b32 s[0], s[{s.s_tmp(1)}], {igemm_log2(n_n1b)}")
             else:
                 self._emit(f"s_lshr_b32 s[{s.s_tmp()}], s[{s.s_n()}], {igemm_log2(n_n0)}")
@@ -1608,7 +1617,7 @@ class igemm_bwd_gtc_t(mc_base_t):
         else:
             self._emit(f"v_add_u32 v[{v.v_tmp(5)}], s[{s.s_block_gtc_in1b()}], v[{v.v_gtc_in1b()}]")
         if self.tunable.nxe != 0:
-            self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_gtc_in1(), v.v_tmp(5), s.s_stride_dslice_hw(), v.v_tmp(), s.s_tmp()))
+            self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_gtc_in1(), v.v_tmp(5), s.s_dslice_dim_b(), v.v_tmp(), s.s_tmp()))
             self._emit(m_int_div_rem_vs(v.v_out_dslice_iw(), v.v_out_dslice_ih(), v.v_tmp(4), s.s_dslice_w(), v.v_tmp(), s.s_tmp()))
             self._emit_empty_line()
             self._emit(f"; iHTildaLeft, iWTildaLeft")
@@ -1827,7 +1836,7 @@ class igemm_bwd_gtc_t(mc_base_t):
         self._emit(f";   compute from n1b")
         if self.tunable.nxe != 0:
             self._emit(f"v_add_u32 v[{v.v_tmp(5)}], s[{s.s_block_gtc_in1b()}], v[{v.v_in_in1b()}]")
-            self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_in_in1(), v.v_tmp(5), s.s_stride_dslice_hw(), v.v_tmp(), s.s_tmp()))
+            self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_in_in1(), v.v_tmp(5), s.s_dslice_dim_b(), v.v_tmp(), s.s_tmp()))
             self._emit(m_int_div_rem_vs(v.v_in_dslice_iw(), v.v_in_dslice_ih(), v.v_tmp(4), s.s_dslice_w(), v.v_tmp(), s.s_tmp()))
             self._emit_empty_line()
             self._emit(f"v_add_u32 v[{v.v_in_dslice_ih()}], s[{s.s_dslice_h_left()}], v[{v.v_in_dslice_ih()}]")

--- a/igemm/algo/igemm_bwd_gtc.py
+++ b/igemm/algo/igemm_bwd_gtc.py
@@ -1493,7 +1493,7 @@ class igemm_bwd_gtc_t(mc_base_t):
             self._emit(f"s_mul_i32 s[{s.s_stride_dslice_hw()}],  s[{s.s_dslice_h()}], s[{s.s_dslice_w()}]")
             self._emit(f"s_mul_i32 s[{s.s_stride_dslice_yx()}],  s[{s.s_dslice_y()}], s[{s.s_dslice_x()}]")
 
-            self._emit(f"; change for padding")
+            self._emit(f"; pad b into multiplier of nxb")
             self._emit(f"s_add_u32 s[{s.s_tmp()}], {self.tunable.nxb - 1}, s[{s.s_stride_dslice_hw()}]")
             self._emit(f"s_lshr_b32 s[{s.s_tmp(1)}], s[{s.s_tmp()}], {igemm_log2(self.tunable.nxb)}")
             self._emit(f"s_lshl_b32 s[{s.s_dslice_dim_b()}], s[{s.s_tmp(1)}], {igemm_log2(self.tunable.nxb)}")

--- a/igemm/algo/igemm_fwd_gtc.py
+++ b/igemm/algo/igemm_fwd_gtc.py
@@ -656,6 +656,9 @@ class igemm_fwd_gtc_t(mc_base_t):
                 self.s_gemm_k_num_y = sym_t("s_gemm_k_num_y"                      , self.s_y.value)
                 self.s_gemm_k_num_x = sym_t("s_gemm_k_num_x"                      , self.s_x.value)
 
+            if outer.tunable.nxe != 0:
+                self.s_dim_b               = sym_t("s_dim_b"                , self.s_move_slice_k_y.value)
+
             self.s_kitr                    = sym_t("s_kitr"                   ,1)
             if outer.tunable.precache_soffset:
                 m_wei_2d_global_load, m_in_2d_global_load         = outer.get_macro_global_load()
@@ -720,7 +723,8 @@ class igemm_fwd_gtc_t(mc_base_t):
             self.v_sld_b_os          = sym_t("v_sld_b_os"     ,vseq(1))
             self.v_in_os             = sym_t("v_in_os"        ,vseq(1))
             self.v_in_os_base        = sym_t("v_in_os_base"   ,vseq(1))
-            self.v_in_flag           = sym_t("v_in_flag"      ,vseq(1))
+            if outer.tunable.nxe != 0:
+                self.v_in_flag       = sym_t("v_in_flag"      ,vseq(1))
             self.v_wei_os            = sym_t("v_wei_os"       ,vseq(1))
 
             self.v_co_sst            = sym_t("v_co_sst"       ,vseq(1))
@@ -738,20 +742,22 @@ class igemm_fwd_gtc_t(mc_base_t):
             self.v_gtc_tb_in1        = sym_t("v_gtc_tb_in1"   ,vseq(1))
             self.v_gtc_tb_ib         = sym_t("v_gtc_tb_ib"    ,vseq(1))
             if outer.tunable.nxe != 0:
-                self.v_gtc_tb_ic1     = sym_t("v_gtc_tb_ic1"   ,vseq(1))
+                self.v_gtc_tb_ic1     = sym_t("v_gtc_tb_ic1"  ,vseq(1))
 
             self.v_out_os            = sym_t("v_out_os"       ,vseq(1))
-            self.v_out_in0           = sym_t("v_out_in0"       ,vseq(1))
-            self.v_out_in1b           = sym_t("v_out_in1b"       ,vseq(1))
-            self.v_out_in1           = sym_t("v_out_in1"       ,vseq(1))
-
-            self.v_in_iho           = sym_t("v_in_iho"      ,vseq(1))
-            self.v_in_iwo           = sym_t("v_in_iwo"      ,vseq(1))
-            self.v_in_ihi           = sym_t("v_in_ihi"      ,vseq(1))
-            self.v_in_iwi           = sym_t("v_in_iwi"      ,vseq(1))
             if outer.tunable.nxe != 0:
-                self.v_in_iy            = sym_t("v_in_iy"       ,vseq(1))
-                self.v_in_ix            = sym_t("v_in_ix"       ,vseq(1))
+                self.v_out_flag      = sym_t("v_out_flag"     ,vseq(1))
+            self.v_out_in0           = sym_t("v_out_in0"      ,vseq(1))
+            self.v_out_in1b          = sym_t("v_out_in1b"     ,vseq(1))
+            self.v_out_in1           = sym_t("v_out_in1"      ,vseq(1))
+
+            self.v_in_iho           = sym_t("v_in_iho"        ,vseq(1))
+            self.v_in_iwo           = sym_t("v_in_iwo"        ,vseq(1))
+            self.v_in_ihi           = sym_t("v_in_ihi"        ,vseq(1))
+            self.v_in_iwi           = sym_t("v_in_iwi"        ,vseq(1))
+            if outer.tunable.nxe != 0:
+                self.v_in_iy            = sym_t("v_in_iy"     ,vseq(1))
+                self.v_in_ix            = sym_t("v_in_ix"     ,vseq(1))
 
             self.v_move_slice_k_ic1  = sym_t("v_move_slice_k_ic1" , self.v_gtc_tb_ic1.value if outer.tunable.nxe != 0 else self.v_gtc_tb_ic1e.value)
             if outer.tunable.nxe != 0:
@@ -1423,11 +1429,18 @@ class igemm_fwd_gtc_t(mc_base_t):
         else:
             self._emit(f"s_mov_b32 s[{s.s_knum()}], s[{s.s_c()}]")
 
+        # warp around the really dim_b length, in case pad
+        if self.tunable.nxe != 0:
+            self._emit(f"s_add_u32 s[{s.s_tmp()}], {self.tunable.nxb - 1}, s[{s.s_out_stride_k()}]")
+            self._emit(f"s_lshr_b32 s[{s.s_tmp(1)}], s[{s.s_tmp()}], {igemm_log2(self.tunable.nxb)}")
+            self._emit(f"s_lshl_b32 s[{s.s_dim_b()}], s[{s.s_tmp(1)}], {igemm_log2(self.tunable.nxb)}")
+
+
         self._emit_empty_line()
         self._emit(f"; gemm_m_per_block:{self.tunable.gemm_m_per_block}, gemm_n_per_block:{self.tunable.gemm_n_per_block}, source_access_order:{self.tunable.source_access_order}")
         if self.tunable.source_access_order == IGEMM_GTC_TUNABLE_SOURCE_ACCESS_ORDER_GEMM_M_GEMM_N:
             if self.tunable.nxe != 0:
-                self._emit(f"s_mul_i32 s[{s.s_tmp()}], s[{s.s_out_stride_k()}], s[{s.s_n()}]")
+                self._emit(f"s_mul_i32 s[{s.s_tmp()}], s[{s.s_dim_b()}], s[{s.s_n()}]")
             else:
                 self._emit(f"s_mul_i32 s[{s.s_tmp()}], s[{s.s_stride_hw()}], s[{s.s_n()}]")
 
@@ -1455,12 +1468,12 @@ class igemm_fwd_gtc_t(mc_base_t):
         if gemm_n_unmerge_cluster == 0:
             if self.tunable.nxe != 0:
                 if unmerge_sub_n1 == 1:
-                    self._emit(f"s_lshr_b32 s[0], s[{s.s_out_stride_k()}], {igemm_log2(nb_n1b)} ; total number of n1b")
+                    self._emit(f"s_lshr_b32 s[0], s[{s.s_dim_b()}], {igemm_log2(nb_n1b)} ; total number of n1b")
                 else:
                     if unmerge_sub_n1 == nb_n1b:
-                        self._emit(f"s_mov_b32 s[0], s[{s.s_out_stride_k()}] ; total number of n1b")
+                        self._emit(f"s_mov_b32 s[0], s[{s.s_dim_b()}] ; total number of n1b")
                     else:
-                        self._emit(f"s_lshr_b32 s[0], s[{s.s_out_stride_k()}], {igemm_log2(nb_n1b // unmerge_sub_n1)}  ; total number of n1b")
+                        self._emit(f"s_lshr_b32 s[0], s[{s.s_dim_b()}], {igemm_log2(nb_n1b // unmerge_sub_n1)}  ; total number of n1b")
             else:
                 if unmerge_sub_n1 == 1:
                     self._emit(f"s_lshr_b32 s[0], s[{s.s_stride_hw()}], {igemm_log2(nb_n1b)} ; total number of n1b")
@@ -1472,7 +1485,7 @@ class igemm_fwd_gtc_t(mc_base_t):
         else:
             if self.tunable.nxe != 0:
                 self._emit(f"s_lshr_b32 s[{s.s_tmp()}], s[{s.s_n()}], {igemm_log2(nb_n0)}")
-                self._emit(f"s_mul_i32 s[{s.s_tmp(1)}], s[{s.s_out_stride_k()}], s[{s.s_tmp()}]")
+                self._emit(f"s_mul_i32 s[{s.s_tmp(1)}], s[{s.s_dim_b()}], s[{s.s_tmp()}]")
                 self._emit(f"s_lshr_b32 s[0], s[{s.s_tmp(1)}], {igemm_log2(nb_n1b)}")
             else:
                 self._emit(f"s_lshr_b32 s[{s.s_tmp()}], s[{s.s_n()}], {igemm_log2(nb_n0)}")
@@ -1526,11 +1539,11 @@ class igemm_fwd_gtc_t(mc_base_t):
         if self.tunable.nxe != 0:
             if IGEMM_GTC_FEAT_MAGIC_DIVISION:
                 self._emit(f"s_bfe_u32 s[{s.s_tmp(3)}], s[{s.s_shift_pack_1()}], 0x00080000 ; offset:0, width:8")
-                self._emit(m_mdiv_u32_vs(v.v_tmp(4), v.v_gtc_tb_in1(), v.v_tmp(5), s.s_magic_4(), s.s_tmp(3), s.s_out_stride_k(), v.v_tmp()))
+                self._emit(m_mdiv_u32_vs(v.v_tmp(4), v.v_gtc_tb_in1(), v.v_tmp(5), s.s_magic_4(), s.s_tmp(3), s.s_dim_b(), v.v_tmp()))
                 self._emit(f"s_bfe_u32 s[{s.s_tmp(3)}], s[{s.s_shift_pack_1()}], 0x00080008 ; offset:8, width:8")
                 self._emit(m_mdiv_u32_vs(v.v_in_iwo(), v.v_in_iho(), v.v_tmp(4), s.s_magic_5(), s.s_tmp(3), s.s_wo(), v.v_tmp()))
             else:
-                self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_gtc_tb_in1(), v.v_tmp(5), s.s_out_stride_k(), v.v_tmp(), s.s_tmp()))
+                self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_gtc_tb_in1(), v.v_tmp(5), s.s_dim_b(), v.v_tmp(), s.s_tmp()))
                 self._emit(m_int_div_rem_vs(v.v_in_iwo(), v.v_in_iho(), v.v_tmp(4), s.s_wo(), v.v_tmp(), s.s_tmp()))
             self._emit(f"v_mul_lo_u32 v[{v.v_in_iho()}], s[{s.s_stride_h()}], v[{v.v_in_iho()}]")
             self._emit(f"v_sub_i32 v[{v.v_in_iho()}], v[{v.v_in_iho()}], s[{s.s_pad_h()}]")
@@ -1752,11 +1765,11 @@ class igemm_fwd_gtc_t(mc_base_t):
         if self.tunable.nxe != 0:
             if IGEMM_GTC_FEAT_MAGIC_DIVISION:
                 self._emit(f"s_bfe_u32 s[{s.s_tmp(3)}], s[{s.s_shift_pack_1()}], 0x00080000 ; offset:0, width:8")
-                self._emit(m_mdiv_u32_vs(v.v_tmp(4), v.v_out_in1(), v.v_tmp(5), s.s_magic_4(), s.s_tmp(3), s.s_out_stride_k(), v.v_tmp()))
+                self._emit(m_mdiv_u32_vs(v.v_tmp(4), v.v_out_in1(), v.v_tmp(5), s.s_magic_4(), s.s_tmp(3), s.s_dim_b(), v.v_tmp()))
                 self._emit(f"s_bfe_u32 s[{s.s_tmp(3)}], s[{s.s_shift_pack_1()}], 0x00080008 ; offset:8, width:8")
                 self._emit(m_mdiv_u32_vs(v.v_out_iwo(), v.v_out_iho(), v.v_tmp(4), s.s_magic_5(), s.s_tmp(3), s.s_wo(), v.v_tmp()))
             else:
-                self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_out_in1(), v.v_tmp(5), s.s_out_stride_k(), v.v_tmp(), s.s_tmp()))
+                self._emit(m_int_div_rem_vs(v.v_tmp(4), v.v_out_in1(), v.v_tmp(5), s.s_dim_b(), v.v_tmp(), s.s_tmp()))
                 self._emit(m_int_div_rem_vs(v.v_out_iwo(), v.v_out_iho(), v.v_tmp(4), s.s_wo(), v.v_tmp(), s.s_tmp()))
             self._emit_empty_line()
         else:
@@ -1813,6 +1826,8 @@ class igemm_fwd_gtc_t(mc_base_t):
         self._emit(f"v_mul_lo_u32 v[{v.v_tmp(1)}], s[{s.s_wo() if self.tunable.nxe != 0 else s.s_wi()}], v[{v.v_out_iho()}]")
         self._emit(f"v_add3_u32 v[{v.v_out_os()}], v[{v.v_out_os()}], v[{v.v_tmp(1)}], v[{v.v_out_iwo()}]")
         self._emit(f"v_lshlrev_b32 v[{v.v_out_os()}], {igemm_log2(data_byte)}, v[{v.v_out_os()}]")
+        if self.tunable.nxe != 0:
+            self._emit(m_set_flag_hw(v.v_out_flag(), v.v_out_iho(), v.v_out_iwo(), s.s_ho(), s.s_wo()))
 
         self._emit(f"; move slice stride")
         assert na_c0 * na_c1e == self.tunable.gemm_k_per_block and nb_c0 * nb_c1e == self.tunable.gemm_k_per_block
@@ -2037,7 +2052,8 @@ class igemm_fwd_gtc_t(mc_base_t):
             a = self.agpr
   
             self._emit(self.coalescing_store(a.a_c(), v.v_c(), v.v_co_sst(), v.v_co_sld(), s.s_p_out(), v.v_out_os(), None,
-                    s.s_out_stride_k0() if self.tunable.gemm_m_unmerge_cluster == 1 else None, s.s_out_stride_k(), s.s_tmp()))
+                    s.s_out_stride_k0() if self.tunable.gemm_m_unmerge_cluster == 1 else None, s.s_out_stride_k(), s.s_tmp(),
+                    v.v_out_flag() if self.tunable.nxe != 0 else None))
 
         self._emit_front(f"{self.label_out}:")
 

--- a/igemm/algo/igemm_fwd_gtc.py
+++ b/igemm/algo/igemm_fwd_gtc.py
@@ -706,7 +706,7 @@ class igemm_fwd_gtc_t(mc_base_t):
             else:
                 v_c_resuable_num     = outer.tunable.num_vgpr_accumulate_a + outer.tunable.num_vgpr_accumulate_b + \
                                         outer.tunable.num_vgpr_global_load_a + outer.tunable.num_vgpr_global_load_b + \
-                                        8       # from v_sst_a_os to v_wei_os
+                                        16       # from v_sst_a_os to v_co_sst
                 v_c_coalescing_num   = outer.tunable.num_agpr_accumulate_c // outer.coalescing_store_groups
                 v_c_needed           = (v_c_coalescing_num - v_c_resuable_num) if (v_c_coalescing_num - v_c_resuable_num) > 0 else 0
 
@@ -727,9 +727,6 @@ class igemm_fwd_gtc_t(mc_base_t):
                 self.v_in_flag       = sym_t("v_in_flag"      ,vseq(1))
             self.v_wei_os            = sym_t("v_wei_os"       ,vseq(1))
 
-            self.v_co_sst            = sym_t("v_co_sst"       ,vseq(1))
-            self.v_co_sld            = sym_t("v_co_sld"       ,vseq(1))
-
             self.v_gtc_ta_ik1        = sym_t("v_gtc_ta_ik1"   ,vseq(1))
             self.v_gtc_ta_ik0        = sym_t("v_gtc_ta_ik0"   ,vseq(1))
             self.v_gtc_ta_ic1e       = sym_t("v_gtc_ta_ic1e"  ,vseq(1))
@@ -743,6 +740,9 @@ class igemm_fwd_gtc_t(mc_base_t):
             self.v_gtc_tb_ib         = sym_t("v_gtc_tb_ib"    ,vseq(1))
             if outer.tunable.nxe != 0:
                 self.v_gtc_tb_ic1     = sym_t("v_gtc_tb_ic1"  ,vseq(1))
+
+            self.v_co_sst            = sym_t("v_co_sst"       ,vseq(1))
+            self.v_co_sld            = sym_t("v_co_sld"       ,vseq(1))
 
             self.v_out_os            = sym_t("v_out_os"       ,vseq(1))
             if outer.tunable.nxe != 0:

--- a/igemm/codegen/compile.py
+++ b/igemm/codegen/compile.py
@@ -141,7 +141,7 @@ class compile_host_t(object):
             if IGEMM_HOST_USE_XDNN:
                 cmd += [f'-I{bytes.fromhex(xdnnroot).decode()}/include', '-DUSE_XDNN']
             if IGEMM_HOST_USE_MAGIC_DIV:
-                cmd += ['-DUSE_MAGIC_DIV']
+                cmd += ['-DUSE_MAGIC_DIV=1']
             if 'cflags' in kwargs:
                 cmd += kwargs['cflags']
             if 'cxxflags' in kwargs:


### PR DESCRIPTION
support image size pad to modulo of gemm_n_per_block.
`b=ho*wo, b % nxb == 0`
indeed we only need pad to modulo of `nxb` in each generated kernel.
And reuse  `v_in_flag`, `v_out_flag` while check input/output hw

- [x] fwd
- [x] bwd

cc: @asroy 