### PR TITLE
Fix vgpr index calculation in macro_igemm_2d_shared_store_t of shared_memory.py

### DIFF
--- a/igemm/algo/shared_memory.py
+++ b/igemm/algo/shared_memory.py
@@ -805,7 +805,7 @@ class macro_igemm_2d_shared_store_t(macro_base_t):
                     for i_d1 in range(num_vector_d1 // 2):
                         i_offset = i_d0 * ctrl.stride_d0 + 2* i_d1 * ctrl.stride_d1
                         self._emit(ds_write2(f'{self.v_sst_os()}',
-                                f'{self.v_src()}+{(i_d0 * ctrl.length_d1 + 2*i_d1)*ctrl.vector_d1}',
+                                f'{self.v_src()}+{i_d0 * ctrl.length_d1 + 2*i_d1*ctrl.vector_d1}',
                                 i_offset))
                         issue_cnt += ds_write2.get_issues(i_offset)
             else:


### PR DESCRIPTION
The buggy codes does not cause issue by fwd-fp32 (igemm_gtc_fwd.py) since 
1) in_sst_ctrl.vector_d1 is detected to be always 1 for all the configurations
2) wei_sst_ctrl.src_order =1, which lets the sst codes does not take the buggy path