### PR TITLE
Mfma fp16 review

### DIFF
--- a/igemm/algo/coalescing_store.py
+++ b/igemm/algo/coalescing_store.py
@@ -1077,7 +1077,12 @@ class igemm_coalescing_store_xdlops_t(mc_base_t):
         no_s_out_offset = s_out_offset is None
 
         # for xdlops, always consider granularity in column, hence here is always ds_write_b128/ds_read_b128
-        inst_sst = inst_ds_write_t(AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M * ctrl.data_byte)
+
+        if ctrl.data_byte == 2:
+            inst_sst = inst_ds_write_words_t(self.mc, AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M)
+        else:
+            inst_sst = inst_ds_write_dwords_t(AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M)
+        
         inst_sld = inst_ds_read_t(AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M * ctrl.data_byte)
         if ctrl.gemm_k_global_split: 
             inst_gst = inst_buffer_atomic_add_dword_t(ctrl.vector_write_out * ctrl.data_byte) 

--- a/igemm/algo/igemm_fwd_gtc.py
+++ b/igemm/algo/igemm_fwd_gtc.py
@@ -881,6 +881,9 @@ class igemm_fwd_gtc_t(mc_base_t):
         ctrl_wei_gld = ctrl_2d_global_load_t()
         ctrl_in_gld = ctrl_2d_global_load_t()
 
+        ctrl_wei_gld.precision = self.tunable.precision
+        ctrl_in_gld.precision = self.tunable.precision
+
         if self.tunable.precision == "fp32":
             ctrl_wei_gld.data_bytes = 4
             ctrl_in_gld.data_bytes  = 4


### PR DESCRIPTION
Add support of fp16/bp16 transfer for global_load and shared_store.  Tested with the original single configuration. Also some commented codes in shared_memory.py are removed.  Only global_memory.py and shared_memory.py are involved. 