### PR TITLE
Updates to let global_load/shared_store/shared_load to support fp16/bp16

### DIFF
--- a/igemm/algo/coalescing_store.py
+++ b/igemm/algo/coalescing_store.py
@@ -1079,9 +1079,9 @@ class igemm_coalescing_store_xdlops_t(mc_base_t):
         # for xdlops, always consider granularity in column, hence here is always ds_write_b128/ds_read_b128
 
         if ctrl.data_byte == 2:
-            inst_sst = inst_ds_write_words_t(self.mc, AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M)
+            inst_sst = inst_ds_write_b16_t(self.mc, AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M)
         else:
-            inst_sst = inst_ds_write_dwords_t(AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M)
+            inst_sst = inst_ds_write_b32_t(AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M)
         
         inst_sld = inst_ds_read_t(AMDGPU_XDLOPS_LANEGROUP_GRANULARITY_M * ctrl.data_byte)
         if ctrl.gemm_k_global_split: 

--- a/igemm/algo/global_memory.py
+++ b/igemm/algo/global_memory.py
@@ -68,11 +68,7 @@ class inst_buffer_load_short_t(mc_base_t):
                 self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
                 self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
             if self.words == 3:
-                self._emit(f"buffer_load_dword v[{vdst}], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}")
-                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
-                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
-                self._emit(f"v_mov_b32 v[{vdst}+2], 0")
-                self._emit(f"buffer_load_short_d16 v[{vdst}+2], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}+4")
+                assert false, "vector load does not support vector size 3 with fp16/bp16"
             if self.words == 4:
                 self._emit(f"buffer_load_dwordx2 v[{vdst}:{vdst}+1], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}")
                 self._emit(f"v_lshrrev_b32 v[{vdst}+3], 16, v[{vdst}+1]")
@@ -238,9 +234,6 @@ class macro_igemm_2d_global_load_t(macro_base_t):
     def get_issues(self):
         ctrl = self.ctrl
         n_d1 = ctrl.length_d1 // ctrl.vector_d1
-        ## for fp16/bp16 two instructions needed to load three words
-        if ctrl.precision != 'fp32' and ctrl.vector_d1 == 3:
-            n_d1 = n_d1 * 2
         return  ctrl.length_d0 * n_d1
 
 

--- a/igemm/algo/global_memory.py
+++ b/igemm/algo/global_memory.py
@@ -48,7 +48,7 @@ class inst_buffer_load_dword_t(object):
             return f"buffer_load_dwordx4 v[{vdst}:{vdst}+3], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}"
         assert False
 
-class inst_buffer_load_word_t(mc_base_t):
+class inst_buffer_load_short_t(mc_base_t):
     def __init__(self, mc, words):
         mc_base_t.__init__(self, mc)
         self.words = words
@@ -174,20 +174,20 @@ class macro_igemm_2d_global_load_t(macro_base_t):
         n_d1 = ctrl.length_d1 // ctrl.vector_d1
         ##assert ctrl.precision == 'fp16', "TO BE supported"
         if ctrl.precision == 'fp32':
-            buffer_load_dw_w = inst_buffer_load_dword_t(ctrl.vector_d1)
+            buffer_load_dword_short = inst_buffer_load_dword_t(ctrl.vector_d1)
         else:
-            buffer_load_dw_w = inst_buffer_load_word_t(self.mc, ctrl.vector_d1)
+            buffer_load_dword_short = inst_buffer_load_short_t(self.mc, ctrl.vector_d1)
         #with self._emit_macro_indented('.macro {} v_dst, s_ptr, v_os, s_stride_d0, s_stride_d1, s_tmp2'.format(self.name())):
         if ctrl.src_order == 0 and ctrl.dst_order == 0:
             i_dst = 0
             for i_d0 in range(ctrl.length_d0):
                 for i_d1 in range(n_d1):
                     if i_d1 == 0 and i_d0 == 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d1 == 0 and i_d0 != 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
                     else:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
 
                     if i_d1 != (n_d1 - 1):
                         if i_d1 == 0 and i_d0 ==  0:
@@ -208,11 +208,11 @@ class macro_igemm_2d_global_load_t(macro_base_t):
             for i_d1 in range(ctrl.length_d1):
                 for i_d0 in range(ctrl.length_d0):
                     if i_d0 == 0 and i_d1 == 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d0 == 0 and i_d1 != 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
                     else:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
 
                     if i_d0 != (ctrl.length_d0 - 1):
                         if i_d0 == 0 and i_d1 ==  0:
@@ -354,9 +354,9 @@ class macro_igemm_2d_global_load_precache_soffset_t(macro_base_t):
         n_d1 = ctrl.length_d1 // ctrl.vector_d1
         ##assert ctrl.precision == 'fp16', "TO BE supported"
         if ctrl.precision == 'fp32':
-            buffer_load_dw_w = inst_buffer_load_dword_t(ctrl.vector_d1)
+            buffer_load_dword_short = inst_buffer_load_dword_t(ctrl.vector_d1)
         else:
-            buffer_load_dw_w = inst_buffer_load_word_t(self.mc, ctrl.vector_d1)
+            buffer_load_dword_short = inst_buffer_load_short_t(self.mc, ctrl.vector_d1)
         #with self._emit_macro_indented('.macro {} v_dst, s_ptr, v_os, s_stride_d0, s_stride_d1, s_offset'.format(self.name())):
         # self._emit(f".v_clear_nc \\v_dst, {ctrl.length_d0 * ctrl.length_d1}")
         if ctrl.src_order == 0 and ctrl.dst_order == 0:
@@ -365,13 +365,13 @@ class macro_igemm_2d_global_load_precache_soffset_t(macro_base_t):
             for i_d0 in range(ctrl.length_d0):
                 for i_d1 in range(n_d1):
                     if i_d0 == 0 and i_d1 == 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d0 == 0 and i_d1 == 1:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
                     elif i_d0 == 1 and i_d1 == 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
                     else:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
                         i_soffset += 1
                     i_dst = i_dst + 1
 
@@ -381,15 +381,15 @@ class macro_igemm_2d_global_load_precache_soffset_t(macro_base_t):
             for i_d1 in range(ctrl.length_d1):
                 for i_d0 in range(ctrl.length_d0):
                     if i_d0 == 0 and i_d1 == 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d0 == 0 and i_d1 == 1:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
                     elif i_d0 == 1 and i_d1 == 0:
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
                     else:
                         i_soffset = index_mapping[i_d0][i_d1]
                         assert i_soffset != 1, "impossible"
-                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
+                        self._emit(buffer_load_dword_short(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
         elif ctrl.src_order == 0 and ctrl.dst_order == 1:
             assert False, "un implemented"
         elif ctrl.src_order == 1 and ctrl.dst_order == 1:

--- a/igemm/algo/global_memory.py
+++ b/igemm/algo/global_memory.py
@@ -27,11 +27,10 @@ from __future__ import print_function
 import sys
 from ..codegen import *
 
-
 class inst_buffer_load_dword_t(object):
     ''' TODO: this implementation always offen '''
-    def __init__(self, data_bytes):
-        self.data_bytes = data_bytes
+    def __init__(self, dwords):
+        self.dwords = dwords
 
     def __call__(self, vdst, vaddr, srsrc, soffset, offset):
         if type(soffset) is int and soffset == 0:
@@ -39,17 +38,48 @@ class inst_buffer_load_dword_t(object):
         else:
             soffset_str = f"s[{soffset}]"
 
-        if self.data_bytes == 2:
-            return f"buffer_load_short_d16 v[{vdst}], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}"
-        if self.data_bytes == 4:
+        if self.dwords == 1:
             return f"buffer_load_dword v[{vdst}], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}"
-        if self.data_bytes == 8:
+        if self.dwords == 2:
             return f"buffer_load_dwordx2 v[{vdst}:{vdst}+1], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}"
-        if self.data_bytes == 12:
+        if self.dwords == 3:
             return f"buffer_load_dwordx3 v[{vdst}:{vdst}+2], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}"
-        if self.data_bytes == 16:
+        if self.dwords == 4:
             return f"buffer_load_dwordx4 v[{vdst}:{vdst}+3], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}"
         assert False
+
+class inst_buffer_load_word_t(mc_base_t):
+    def __init__(self, mc, words):
+        mc_base_t.__init__(self, mc)
+        self.words = words
+
+    def __call__(self, vdst, vaddr, srsrc, soffset, offset):
+        if type(soffset) is int and soffset == 0:
+            soffset_str = "0"
+        else:
+            soffset_str = f"s[{soffset}]"
+        ## assume each vpgr stores one fp16 unit 
+        with self._deferred_context():
+            if self.words == 1:
+                self._emit(f"v_mov_b32 v[{vdst}], 0")
+                self._emit(f"buffer_load_short_d16 v[{vdst}], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}")
+            if self.words == 2:
+                self._emit(f"buffer_load_dword v[{vdst}], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}")
+                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
+                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
+            if self.words == 3:
+                self._emit(f"buffer_load_dword v[{vdst}], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}")
+                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
+                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
+                self._emit(f"v_mov_b32 v[{vdst}+2], 0")
+                self._emit(f"buffer_load_short_d16 v[{vdst}+2], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}+4")
+            if self.words == 4:
+                self._emit(f"buffer_load_dwordx2 v[{vdst}:{vdst}+1], v[{vaddr}], s[{srsrc}:{srsrc}+3], {soffset_str} offen offset:{offset}")
+                self._emit(f"v_lshrrev_b32 v[{vdst}+3], 16, v[{vdst}+1]")
+                self._emit(f"v_and_b32 v[{vdst}+2], 0xffff, v[{vdst}+1]")
+                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
+                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
+        return self._get_deferred()
 
 class inst_buffer_store_dword_t(object):
     ''' TODO: this implementation always offen '''
@@ -108,6 +138,7 @@ class macro_igemm_2d_global_load_t(macro_base_t):
         assert type(ctrl) is ctrl_2d_global_load_t
         macro_base_t.__init__(self, mc, inline)
         self.ctrl = ctrl
+        self.issues = 0
         self.declare_arg("v_dst")
         self.declare_arg("s_ptr")
         self.declare_arg("v_os")
@@ -141,19 +172,22 @@ class macro_igemm_2d_global_load_t(macro_base_t):
         ctrl = self.ctrl
         assert ctrl.length_d1 % ctrl.vector_d1 == 0
         n_d1 = ctrl.length_d1 // ctrl.vector_d1
-        assert ctrl.precision == 'fp32', "TO BE supported"
-        buffer_load_dword = inst_buffer_load_dword_t(ctrl.vector_d1 * ctrl.data_bytes)
+        ##assert ctrl.precision == 'fp16', "TO BE supported"
+        if ctrl.precision == 'fp32':
+            buffer_load_dw_w = inst_buffer_load_dword_t(ctrl.vector_d1)
+        else:
+            buffer_load_dw_w = inst_buffer_load_word_t(self.mc, ctrl.vector_d1)
         #with self._emit_macro_indented('.macro {} v_dst, s_ptr, v_os, s_stride_d0, s_stride_d1, s_tmp2'.format(self.name())):
         if ctrl.src_order == 0 and ctrl.dst_order == 0:
             i_dst = 0
             for i_d0 in range(ctrl.length_d0):
                 for i_d1 in range(n_d1):
                     if i_d1 == 0 and i_d0 == 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d1 == 0 and i_d0 != 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
                     else:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
 
                     if i_d1 != (n_d1 - 1):
                         if i_d1 == 0 and i_d0 ==  0:
@@ -174,11 +208,11 @@ class macro_igemm_2d_global_load_t(macro_base_t):
             for i_d1 in range(ctrl.length_d1):
                 for i_d0 in range(ctrl.length_d0):
                     if i_d0 == 0 and i_d1 == 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d0 == 0 and i_d1 != 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}+1", 0))
                     else:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_d0 * ctrl.length_d1 + i_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_tmp2()}", 0))
 
                     if i_d0 != (ctrl.length_d0 - 1):
                         if i_d0 == 0 and i_d1 ==  0:
@@ -204,6 +238,9 @@ class macro_igemm_2d_global_load_t(macro_base_t):
     def get_issues(self):
         ctrl = self.ctrl
         n_d1 = ctrl.length_d1 // ctrl.vector_d1
+        ## for fp16/bp16 two instructions needed to load three words
+        if ctrl.precision != 'fp32' and ctrl.vector_d1 == 3:
+            n_d1 = n_d1 * 2
         return  ctrl.length_d0 * n_d1
 
 
@@ -315,8 +352,11 @@ class macro_igemm_2d_global_load_precache_soffset_t(macro_base_t):
         ctrl = self.ctrl
         assert ctrl.length_d1 % ctrl.vector_d1 == 0
         n_d1 = ctrl.length_d1 // ctrl.vector_d1
-        assert ctrl.precision == 'fp32', "TO BE supported"
-        buffer_load_dword = inst_buffer_load_dword_t(ctrl.vector_d1 * ctrl.data_bytes)
+        ##assert ctrl.precision == 'fp16', "TO BE supported"
+        if ctrl.precision == 'fp32':
+            buffer_load_dw_w = inst_buffer_load_dword_t(ctrl.vector_d1)
+        else:
+            buffer_load_dw_w = inst_buffer_load_word_t(self.mc, ctrl.vector_d1)
         #with self._emit_macro_indented('.macro {} v_dst, s_ptr, v_os, s_stride_d0, s_stride_d1, s_offset'.format(self.name())):
         # self._emit(f".v_clear_nc \\v_dst, {ctrl.length_d0 * ctrl.length_d1}")
         if ctrl.src_order == 0 and ctrl.dst_order == 0:
@@ -325,13 +365,13 @@ class macro_igemm_2d_global_load_precache_soffset_t(macro_base_t):
             for i_d0 in range(ctrl.length_d0):
                 for i_d1 in range(n_d1):
                     if i_d0 == 0 and i_d1 == 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d0 == 0 and i_d1 == 1:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
                     elif i_d0 == 1 and i_d1 == 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
                     else:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
                         i_soffset += 1
                     i_dst = i_dst + 1
 
@@ -341,15 +381,15 @@ class macro_igemm_2d_global_load_precache_soffset_t(macro_base_t):
             for i_d1 in range(ctrl.length_d1):
                 for i_d0 in range(ctrl.length_d0):
                     if i_d0 == 0 and i_d1 == 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", 0, 0))
                     elif i_d0 == 0 and i_d1 == 1:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d1()}", 0))
                     elif i_d0 == 1 and i_d1 == 0:
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_stride_d0()}", 0))
                     else:
                         i_soffset = index_mapping[i_d0][i_d1]
                         assert i_soffset != 1, "impossible"
-                        self._emit(buffer_load_dword(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
+                        self._emit(buffer_load_dw_w(f"{self.v_dst()}+{i_dst*ctrl.vector_d1}", f"{self.v_os()}", f"{self.s_ptr()}", f"{self.s_offset()}+{i_soffset}", 0))
         elif ctrl.src_order == 0 and ctrl.dst_order == 1:
             assert False, "un implemented"
         elif ctrl.src_order == 1 and ctrl.dst_order == 1:

--- a/igemm/algo/igemm_bwd_gtc.py
+++ b/igemm/algo/igemm_bwd_gtc.py
@@ -2060,13 +2060,13 @@ class igemm_bwd_gtc_t(mc_base_t):
                 fctrl.shared_load_a_functor   = inst_ds_read_t(data_byte)   # xdlops load from LDS always single load
             else:
                 assert ctrl_xdlops_mapping.wave_step_m == 2, "currently only support wave_step_m is 2"
-                fctrl.shared_load_a_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, data_byte, ctrl_xdlops_mapping.wave_tile_m * data_byte, sym_t(self.vgpr.v_tmp(4)))
+                fctrl.shared_load_a_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, 1, data_byte, ctrl_xdlops_mapping.wave_tile_m * data_byte, sym_t(self.vgpr.v_tmp(4)))
 
             if ctrl_xdlops_mapping.wave_step_n == 1:
                 fctrl.shared_load_b_functor   = inst_ds_read_t(data_byte)   # xdlops load from LDS always single load
             else:
                 assert ctrl_xdlops_mapping.wave_step_n == 2, "currently only support wave_step_n is 2"
-                fctrl.shared_load_b_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, data_byte, ctrl_xdlops_mapping.wave_tile_n * data_byte, sym_t(self.vgpr.v_tmp(5)))
+                fctrl.shared_load_b_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, 1, data_byte, ctrl_xdlops_mapping.wave_tile_n * data_byte, sym_t(self.vgpr.v_tmp(5)))
             fctrl.move_slice_window_a_functor = move_slice_window_a
             fctrl.move_slice_window_b_functor = move_slice_window_b
 

--- a/igemm/algo/igemm_fwd_gtc.py
+++ b/igemm/algo/igemm_fwd_gtc.py
@@ -437,7 +437,6 @@ class igemm_fwd_gtc_t(mc_base_t):
 
         return gemm_m_order, gemm_n_order
 
-
     class global_load_in_t(mc_base_t):
         def __init__(self, mc, outer):
             mc_base_t.__init__(self, mc)
@@ -880,6 +879,9 @@ class igemm_fwd_gtc_t(mc_base_t):
 
         ctrl_wei_gld = ctrl_2d_global_load_t()
         ctrl_in_gld = ctrl_2d_global_load_t()
+
+        ctrl_wei_gld.precision = self.tunable.precision
+        ctrl_in_gld.precision = self.tunable.precision
 
         if self.tunable.precision == "fp32":
             ctrl_wei_gld.data_bytes = 4
@@ -2029,13 +2031,13 @@ class igemm_fwd_gtc_t(mc_base_t):
                 fctrl.shared_load_a_functor   = inst_ds_read_t(data_byte * self.tunable.gemm_k_pack)   # xdlops load from LDS always single load
             else:
                 assert ctrl_xdlops_mapping.wave_step_m == 2, "currently only support wave_step_m is 2"
-                fctrl.shared_load_a_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, data_byte, ctrl_xdlops_mapping.wave_tile_m * data_byte, sym_t(self.vgpr.v_tmp(4)))
+                fctrl.shared_load_a_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, 1, data_byte, ctrl_xdlops_mapping.wave_tile_m * data_byte, sym_t(self.vgpr.v_tmp(4)))
 
             if ctrl_xdlops_mapping.wave_step_n == 1:
                 fctrl.shared_load_b_functor   = inst_ds_read_t(data_byte * self.tunable.gemm_k_pack)   # xdlops load from LDS always single load
             else:
                 assert ctrl_xdlops_mapping.wave_step_n == 2, "currently only support wave_step_n is 2"
-                fctrl.shared_load_b_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, data_byte, ctrl_xdlops_mapping.wave_tile_n * data_byte, sym_t(self.vgpr.v_tmp(4)))
+                fctrl.shared_load_b_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, 1, data_byte, ctrl_xdlops_mapping.wave_tile_n * data_byte, sym_t(self.vgpr.v_tmp(4)))
             fctrl.move_slice_window_a_functor = move_slice_window_a
             fctrl.move_slice_window_b_functor = move_slice_window_b
 

--- a/igemm/algo/igemm_wrw_gtc.py
+++ b/igemm/algo/igemm_wrw_gtc.py
@@ -1758,13 +1758,13 @@ class igemm_wrw_gtc_t(mc_base_t):
                 fctrl.shared_load_a_functor   = inst_ds_read_t(data_byte * self.tunable.gemm_k_pack)   # xdlops load from LDS always single load
             else:
                 assert ctrl_xdlops_mapping.wave_step_m == 2, "currently only support wave_step_m is 2"
-                fctrl.shared_load_a_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, data_byte, ctrl_xdlops_mapping.wave_tile_m * data_byte, sym_t(self.vgpr.v_tmp(4)))
+                fctrl.shared_load_a_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, 1, data_byte, ctrl_xdlops_mapping.wave_tile_m * data_byte, sym_t(self.vgpr.v_tmp(4)))
 
             if ctrl_xdlops_mapping.wave_step_n == 1:
                 fctrl.shared_load_b_functor   = inst_ds_read_t(data_byte)   # xdlops load from LDS always single load
             else:
                 assert ctrl_xdlops_mapping.wave_step_n == 2, "currently only support wave_step_n is 2"
-                fctrl.shared_load_b_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, data_byte, ctrl_xdlops_mapping.wave_tile_n * data_byte, sym_t(self.vgpr.v_tmp(5)))
+                fctrl.shared_load_b_functor   = inst_ds_read2_likely_accumulate_offset_t(self.mc, 2, 1, data_byte, ctrl_xdlops_mapping.wave_tile_n * data_byte, sym_t(self.vgpr.v_tmp(5)))
             fctrl.move_slice_window_a_functor = move_slice_window_a
             fctrl.move_slice_window_b_functor = move_slice_window_b
 

--- a/igemm/algo/shared_memory.py
+++ b/igemm/algo/shared_memory.py
@@ -321,8 +321,6 @@ class inst_ds_read2_likely_t(mc_base_t):
             self.issues = self.vec_count
             ## for fp16/bp16
             if self.data_byte == 2:
-                if self.vector == 3:
-                    self.issues = self.vec_count * 2
                 return emit_read2_fallback(sld_offset)
 
             if self.vec_byte == 4:
@@ -504,8 +502,6 @@ class inst_ds_write2_likely_t(mc_base_t):
             self.issues = self.vec_count
             ## for fp16/bp16
             if self.data_byte == 2:
-                if self.vector == 3: 
-                    self.issues = self.vec_count * 2
                 return emit_write2_fallback(sst_offset)
 
             if self.vec_byte == 4:
@@ -596,12 +592,7 @@ class inst_ds_read_b16_t(mc_base_t):
                 self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
                 self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
             if self.words == 3:
-                self._emit('ds_read_b32 v[{}], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset)))
-                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
-                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
-                self._emit(f"v_mov_b32 v[{vdst}+2], 0")
-                self._emit('ds_read_u16_d16 v[{}+2], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset)))
-                self.issues = 2
+                assert false, "LDS vector read does not support vector size 3 for fp16/bp16"
             if self.words == 4:
                 self._emit('ds_read_b64 v[{}:{}+1], v[{}] {}'.format(vdst, vdst, vaddr, self.get_offset(offset)))
                 self._emit(f"v_lshrrev_b32 v[{vdst}+3], 16, v[{vdst}+1]")
@@ -660,11 +651,7 @@ class inst_ds_write_b16_t(mc_base_t):
                 self._emit('ds_write_b32 v[{}] v[{}] {}'.format(vaddr, vdata, self.get_offset(offset)))
 
             if self.words == 3:
-                self._emit(f"v_lshlrev_b32 v[{vdata}+1], 16, v[{vdata}+1]")
-                self._emit(f"v_or_b32 v[{vdata}], v[{vdata}+1], v[{vdata}]") 
-                self._emit('ds_write_b32 v[{}] v[{}] {}'.format(vaddr, vdata, self.get_offset(offset)))
-                self._emit('ds_write_b32 v[{}] v[{}+1] {}'.format(vaddr, vdata, self.get_offset(offset+4)))
-                issues = 2
+                assert false, "LDS vector write does not support vector size 3 for fp16/bp16"
 
             if self.words == 4:
                 self._emit(f"v_lshlrev_b32 v[{vdata}+1], 16, v[{vdata}+1]")

--- a/igemm/algo/shared_memory.py
+++ b/igemm/algo/shared_memory.py
@@ -285,9 +285,9 @@ class inst_ds_read2_likely_t(mc_base_t):
         v_sld_os = sym_t(v_sld_os)
         def emit_read2_fallback(sld_offset = 0):
             if self.data_byte == 2:
-                sldx1 = inst_ds_read_words_t(self.mc, self.vector)
+                sldx1 = inst_ds_read_b16_t(self.mc, self.vector)
             else:
-                sldx1 = inst_ds_read_dwords_t(self.vector)
+                sldx1 = inst_ds_read_b32_t(self.vector)
             with self._deferred_context():
                 for n in range(self.vec_count):
                     self._emit(sldx1(v_dst(n*self.vector), v_sld_os(), (self.sld_base + sld_offset) + n * self.vec_stride))
@@ -468,9 +468,9 @@ class inst_ds_write2_likely_t(mc_base_t):
             #print(f"vec_byte={self.vec_byte}")
             #print(f"vec_count={self.vec_count}")
             if self.data_byte == 2: 
-               sstx1 = inst_ds_write_words_t(self.mc, self.vector)
+               sstx1 = inst_ds_write_b16_t(self.mc, self.vector)
             else:
-               sstx1 = inst_ds_write_dwords_t(self.vector)
+               sstx1 = inst_ds_write_b32_t(self.vector)
             with self._deferred_context():
                 for n in range(self.vec_count):
                     self._emit(sstx1(v_sst(), v_src(n*self.vector), (self.sst_base + sst_offset) + n * self.vec_stride))
@@ -552,7 +552,7 @@ class inst_ds_read_t(object):
     def get_issues(self):
         return 1
 
-class inst_ds_read_dwords_t(object):
+class inst_ds_read_b32_t(object):
     def __init__(self, dwords):
         self.dwords = dwords
 
@@ -574,7 +574,7 @@ class inst_ds_read_dwords_t(object):
     def get_issues(self):
         return 1
 
-class inst_ds_read_words_t(mc_base_t):
+class inst_ds_read_b16_t(mc_base_t):
     def __init__(self, mc, words):
         mc_base_t.__init__(self, mc)
         self.words = words
@@ -613,7 +613,7 @@ class inst_ds_read_words_t(mc_base_t):
     def get_issues(self):
         return self.issues 
 
-class inst_ds_write_dwords_t(object):
+class inst_ds_write_b32_t(object):
     def __init__(self, dwords):
         self.dwords = dwords
 
@@ -638,7 +638,7 @@ class inst_ds_write_dwords_t(object):
     def get_issues(self):
         return 1
 
-class inst_ds_write_words_t(mc_base_t):
+class inst_ds_write_b16_t(mc_base_t):
     def __init__(self, mc, words):
         mc_base_t.__init__(self, mc)
         self.words = words
@@ -743,9 +743,9 @@ class macro_igemm_2d_shared_store_t(macro_base_t):
                         issue_cnt += ds_write2.get_issues()
                 else:
                     if ctrl.precision == "fp32":
-                        ds_write = inst_ds_write_dwords_t(ctrl.vector_d1)
+                        ds_write = inst_ds_write_b32_t(ctrl.vector_d1)
                     else:
-                        ds_write = inst_ds_write_words_t(self.mc, ctrl.vector_d1)
+                        ds_write = inst_ds_write_b16_t(self.mc, ctrl.vector_d1)
                     for i_d0 in range(ctrl.length_d0):
                         self._emit(ds_write(f'{self.v_sst_os()}', f'{self.v_src()}+{i_d0*ctrl.vector_d1}', i_d0 * ctrl.stride_d0))
                         issue_cnt += ds_write.get_issues()
@@ -759,9 +759,9 @@ class macro_igemm_2d_shared_store_t(macro_base_t):
                     assert ctrl.length_d0 == len(swap_per_row) and ctrl.length_d0 == start_id_per_row
 
                     if ctrl.precision == "fp32":
-                        ds_write = inst_ds_write_dwords_t(ctrl.vector_d1)
+                        ds_write = inst_ds_write_b32_t(ctrl.vector_d1)
                     else:
-                        ds_write = inst_ds_write_words_t(self.mc, ctrl.vector_d1)
+                        ds_write = inst_ds_write_b16_t(self.mc, ctrl.vector_d1)
                     for i_d0 in range(ctrl.length_d0):
                         swap = swap_per_row[i_d0]
                         s_id = start_id_per_row[i_d0]
@@ -774,9 +774,9 @@ class macro_igemm_2d_shared_store_t(macro_base_t):
                     assert ctrl.v_tmp != None
                     trans_seq = simple_transpose_sequencer_t(ctrl.length_d0, ctrl.length_d1)
                     if ctrl.precision == "fp32":
-                        ds_write = inst_ds_write_dwords_t(ctrl.vector_d1)
+                        ds_write = inst_ds_write_b32_t(ctrl.vector_d1)
                     else:
-                        ds_write = inst_ds_write_words_t(self.mc, ctrl.vector_d1)
+                        ds_write = inst_ds_write_b16_t(self.mc, ctrl.vector_d1)
                     for i_d0 in range(ctrl.length_d0):
                         s_id = trans_seq.get_start_id_per_row()[i_d0]
                         for j in range(len(s_id)):

--- a/igemm/algo/shared_memory.py
+++ b/igemm/algo/shared_memory.py
@@ -536,6 +536,8 @@ class inst_ds_read_t(object):
     def get_offset(self, offset):
         return '' if offset == 0 else 'offset:{}'.format(offset)
     def __call__(self, vdst, vaddr, offset):
+        if self.bytes == 2:
+           return 'ds_read_u16_d16 v[{}], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset))
         if self.bytes == 4:
             return 'ds_read_b32 v[{}], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset))
         if self.bytes == 8:
@@ -603,6 +605,33 @@ class inst_ds_read_b16_t(mc_base_t):
 
     def get_issues(self):
         return self.issues 
+
+class inst_ds_write_t(object):
+    def __init__(self, bytes):
+        self.bytes = bytes
+
+    def get_offset(self, offset):
+        if type(offset) is str:
+            return 'offset:{}'.format(offset)
+        if type(offset) is int:
+            return '' if offset == 0 else 'offset:{}'.format(offset)
+        assert False
+
+    def __call__(self, vaddr, vdata, offset = 0):
+        if self.bytes == 2:
+            return 'ds_write_b16 v[{}] v[{}] {}'.format(vaddr, vdata, self.get_offset(offset))
+        if self.bytes == 4:
+            return 'ds_write_b32 v[{}], v[{}] {}'.format(vaddr, vdata, self.get_offset(offset))
+        if self.bytes == 8:
+            return 'ds_write_b64 v[{}], v[{}:{}+1] {}'.format(vaddr, vdata, vdata, self.get_offset(offset))
+        if self.bytes == 12:
+            return 'ds_write_b96 v[{}], v[{}:{}+2] {}'.format(vaddr, vdata, vdata, self.get_offset(offset))
+        if self.bytes == 16:
+            return 'ds_write_b128 v[{}], v[{}:{}+3] {}'.format(vaddr, vdata, vdata, self.get_offset(offset))
+        assert False
+
+    def get_issues(self, sst_offset = 0):
+        return 1
 
 class inst_ds_write_b32_t(object):
     def __init__(self, dwords):

--- a/igemm/algo/shared_memory.py
+++ b/igemm/algo/shared_memory.py
@@ -233,13 +233,16 @@ class inst_ds_read2_likely_t(mc_base_t):
     def name(self):
         return ''
 
-    def __init__(self, mc, vec_count, vec_byte, vec_stride, sld_base = 0):
+    def __init__(self, mc, vec_count, vector, data_byte, vec_stride, sld_base = 0):
         mc_base_t.__init__(self, mc)
         self.vec_count = vec_count
-        self.vec_byte = vec_byte
+        self.vector = vector
+        self.data_byte = data_byte 
+        self.vec_byte = vector * data_byte
         #assert vec_byte in (4, 8)
         self.vec_stride = vec_stride
         self.sld_base = sld_base
+        self.issues = 0
     
     def likely_read2_b32(self, sld_offset = 0):
         if self.vec_byte != 4:
@@ -281,10 +284,13 @@ class inst_ds_read2_likely_t(mc_base_t):
         v_dst = sym_t(v_dst)
         v_sld_os = sym_t(v_sld_os)
         def emit_read2_fallback(sld_offset = 0):
-            sldx1 = inst_ds_read_t(self.vec_byte)
+            if self.data_byte == 2:
+                sldx1 = inst_ds_read_words_t(self.mc, self.vector)
+            else:
+                sldx1 = inst_ds_read_dwords_t(self.vector)
             with self._deferred_context():
                 for n in range(self.vec_count):
-                    self._emit(sldx1(v_dst(n*(self.vec_byte // 4)), v_sld_os(), (self.sld_base + sld_offset) + n * self.vec_stride))
+                    self._emit(sldx1(v_dst(n*self.vector), v_sld_os(), (self.sld_base + sld_offset) + n * self.vec_stride))
             return self._get_deferred()
 
         def emit_read2_b32(sld_offset = 0):
@@ -312,31 +318,35 @@ class inst_ds_read2_likely_t(mc_base_t):
             return self._get_deferred()
 
         def likely_emit(sld_offset = 0):
+            self.issues = self.vec_count
+            ## for fp16/bp16
+            if self.data_byte == 2:
+                if self.vector == 3:
+                    self.issues = self.vec_count * 2
+                return emit_read2_fallback(sld_offset)
+
             if self.vec_byte == 4:
                 if self.likely_read2_b32(sld_offset):
+                    self.issues = self.vec_count // 2
                     return emit_read2_b32(sld_offset)
                 if self.likely_read2st64_b32(sld_offset):
+                    self.issues = self.vec_count // 2
                     return emit_read2st64_b32(sld_offset)
                 return emit_read2_fallback(sld_offset)
             if self.vec_byte == 8:
                 if self.likely_read2_b64(sld_offset):
+                    self.issues = self.vec_count // 2
                     return emit_read2_b64(sld_offset)
                 if self.likely_read2st64_b64(sld_offset):
+                    self.issues = self.vec_count // 2
                     return emit_read2st64_b64(sld_offset)
                 return emit_read2_fallback(sld_offset)
             return emit_read2_fallback(sld_offset)
 
         return likely_emit(sld_offset)
-    #def emit(self):
-    #    assert False, 'dont use emit of this'
-    def get_issues(self, sld_offset = 0):
-        if self.vec_byte == 4:
-            if self.likely_read2_b32(sld_offset) or self.likely_read2st64_b32(sld_offset):
-                return self.vec_count // 2
-        if self.vec_byte == 8:
-            if self.likely_read2_b64(sld_offset) or self.likely_read2st64_b64(sld_offset):
-                return self.vec_count // 2
-        return self.vec_count
+
+    def get_issues(self):
+        return self.issues
 
 
 class inst_ds_read2_likely_accumulate_offset_t(mc_base_t):
@@ -346,9 +356,9 @@ class inst_ds_read2_likely_accumulate_offset_t(mc_base_t):
     def name(self):
         return ''
 
-    def __init__(self, mc, vec_count, vec_byte, vec_stride, v_tmp_sld = sym_t('v_tmp'), sld_base = 0):
+    def __init__(self, mc, vec_count, vector, data_byte, vec_stride, v_tmp_sld = sym_t('v_tmp'), sld_base = 0):
         mc_base_t.__init__(self, mc)
-        self.ds_read2_likely = inst_ds_read2_likely_t(mc, vec_count, vec_byte, vec_stride, sld_base)
+        self.ds_read2_likely = inst_ds_read2_likely_t(mc, vec_count, vector, data_byte, vec_stride, sld_base)
         self.init_sld_offset = 0
         self.first_call = 1
 
@@ -367,7 +377,7 @@ class inst_ds_read2_likely_accumulate_offset_t(mc_base_t):
             self.init_sld_offset = sld_offset       # record the first offset, as a marker for loop over from start
             self.last_sld_offset = sld_offset
             self.first_call = 0
-            assert self.any_read2_likely(sld_offset), "currently we must make sure the first call is using read2"
+            ##assert self.any_read2_likely(sld_offset), "currently we must make sure the first call is using read2"
             return self.ds_read2_likely(v_dst, v_sld_os, sld_offset)
         else:
             if self.init_sld_offset == sld_offset:
@@ -397,148 +407,9 @@ class inst_ds_read2_likely_accumulate_offset_t(mc_base_t):
                         self.last_sld_offset = sld_offset
                         return self._get_deferred()
 
-    def get_issue(self, sld_offset = 0):
+    def get_issue(self):
         # TODO: might have bug
         return self.ds_read2_likely.get_issues()
-
-
-'''
-class inst_ds_write2_likely_t(mc_base_t):   
-    def name(self):
-        return ''
-    def __init__(self, mc, tunable, vec_count, vec_byte, vec_stride, sst_base):
-        igemm_v4r1_dynamic_t.__init__(self, mc, tunable)
-        self.vec_count        = vec_count
-        self.vec_byte     = vec_byte
-        self.vec_stride   = vec_stride
-        (self.sst_base + sst_offset)     = sst_base
-    def likely_write2_b32(self):
-        if self.vec_count % 2 != 0:
-            return False
-        if ((self.sst_base + sst_offset) % 4 == 0) and (self.vec_stride % 4 == 0):
-            if ((self.sst_base + sst_offset) // 4) + (self.vec_stride // 4) * (self.vec_count - 1) < 256:
-                return True
-        return False
-    def likely_write2st64_b32(self):
-        if self.vec_count % 2 != 0:
-            return False
-        if ((self.sst_base + sst_offset) % (4*64) == 0) and (self.vec_stride % 4 == 0):
-            if ((self.sst_base + sst_offset) // (4*64)) + (self.vec_stride // (4*64)) * (self.vec_count - 1) < 256:
-                return True
-        return False
-    def likely_write2_b64(self):
-        if self.vec_count % 2 != 0:
-            return False
-        if ((self.sst_base + sst_offset) % 8 == 0) and (self.vec_stride % 8 == 0):
-            if ((self.sst_base + sst_offset) // 8) + (self.vec_stride // 8) * (self.vec_count - 1) < 256:
-                return True
-        return False
-    def likely_write2st64_b64(self):
-        if self.vec_count % 2 != 0:
-            return False
-        if ((self.sst_base + sst_offset) % (8*64) == 0) and (self.vec_stride % (8*64) == 0):
-            if ((self.sst_base + sst_offset) // (8*64)) + (self.vec_stride // (8*64)) * (self.vec_count - 1) < 256:
-                return True
-        return False
-    def __call__(self, v_src, v_sst):
-        v_src = sym_t(v_src)
-        v_sst = sym_t(v_sst)
-        def emit_write2_fallback():
-            with self._deferred_context():
-                if self.vec_byte == 1:
-                    for n in range(self.vec_count):
-                        self._emit('ds_write_b32 v[{}], v[{}] offset:{}'.format(v_sst(), v_src(n), (self.sst_base + sst_offset) + n * self.vec_stride))
-                elif self.vec_byte == 2:
-                    if self.vec_count == 1:
-                        self._emit('ds_write_b64 v[{}], v[{}:{}] offset:{}'.format(v_sst(), v_src(), v_src(1), (self.sst_base + sst_offset) ))
-                    else:
-                        swap_start = (self.vec_count*self.vec_byte) // 2
-                        for n in range(self.vec_count // 2):
-                            self._emit('v_swap_b32 v[{}], v[{}]'.format(v_src(2*n + 1), v_src(2*n + swap_start)))
-                            self._emit('ds_write_b64 v[{}], v[{}:{}] offset:{}'.format(v_sst(), v_src(2*n), v_src(2*n + 1), (self.sst_base + sst_offset) + 2*n * self.vec_stride))
-                            self._emit('ds_write_b64 v[{}], v[{}:{}] offset:{}'.format(v_sst(), v_src(2*n + swap_start) , v_src(2*n + swap_start + 1), (self.sst_base + sst_offset) + (2*n+1) * self.vec_stride))
-                elif self.vec_byte == 4:
-                    if self.vec_count == 1:
-                        self._emit('ds_write_b128 v[{}], v[{}:{}] offset:{}'.format(v_sst(), v_src(), v_src(3), (self.sst_base + sst_offset) ))
-                    else:
-                        # though we use algorithm in swap_seq to interleave swap with ds_write, but it is still wise to use extra tmp register for swap is half speed
-                        swap_list = amdgpu_swap_sequencer_t(self.vec_count , self.vec_byte)()
-                        # print('self.vec_count:{}, self.vec_byte:{}, {}'.format(self.vec_count , self.vec_byte, swap_list))
-                        for n in range(self.vec_count):
-                            sw = swap_list[n]
-                            if type(sw) is str:
-                                pass
-                            else:
-                                for sw_item in sw:
-                                    self._emit('v_swap_b32 v[{}], v[{}]'.format(v_src(sw_item[0]) , v_src(sw_item[1]) ))
-                            self._emit('ds_write_b128 v[{}], v[{}:{}] offset:{}'.format(v_sst(), v_src(4*n), v_src(4*n + 3), (self.sst_base + sst_offset) + n * self.vec_stride))
-                else:
-                    assert False, 'unsupported vector size'
-            return self._get_deferred()
-
-        def emit_write2_b32():
-            with self._deferred_context():
-                for n in range(self.vec_count // 2):
-                    self._emit('ds_write2_b32 v[{}], v[{}], v[{}], offset0:{}, offset1:{}'.format(v_sst(),
-                                v_src(2*n), v_src(2*n+1),
-                                ((self.sst_base + sst_offset)//4)+2*n*(self.vec_stride//4), ((self.sst_base + sst_offset)//4)+(2*n+1)*(self.vec_stride//4)))
-            return self._get_deferred()
-
-        def emit_write2st64_b32():
-            with self._deferred_context():
-                for n in range(self.vec_count // 2):
-                    self._emit('ds_write2st64_b32 v[{}], v[{}], v[{}], offset0:{}, offset1:{}'.format(v_sst(),
-                                v_src(2*n), v_src(2*n+1),
-                                ((self.sst_base + sst_offset)//(4*64))+2*n*(self.vec_stride//(4*64)), ((self.sst_base + sst_offset)//(4*64))+(2*n+1)*(self.vec_stride//(4*64))))
-            return self._get_deferred()
-
-        def emit_write2_b64():
-            swap_start = (self.vec_count*self.vec_byte) // 2
-            with self._deferred_context():
-                for n in range(self.vec_count // 2):
-                    self._emit('v_swap_b32 v[{}], v[{}]'.format(v_src(2*n+1), v_src(2*n+swap_start)))
-                    self._emit('ds_write2_b64 v[{}], v[{}:{}], v[{}:{}], offset0:{}, offset1:{}'.format(v_sst(),
-                            v_src(2*n), v_src(2*n+1), v_src(2*n+swap_start), v_src(2*n+swap_start+1),
-                            ((self.sst_base + sst_offset)//8)+2*n*(self.vec_stride//8), ((self.sst_base + sst_offset)//8)+(2*n+1)*(self.vec_stride//8)))
-            return self._get_deferred()
-
-        def emit_write2st64_b64():
-            swap_start = (self.vec_count*self.vec_byte) // 2
-            with self._deferred_context():
-                for n in range(self.vec_count // 2):
-                    self._emit('v_swap_b32 v[{}], v[{}]'.format(v_src(2*n+1), v_src(2*n+swap_start)))
-                    self._emit('ds_write2st64_b64 v[{}], v[{}:{}], v[{}:{}], offset0:{}, offset1:{}'.format(v_sst(),
-                            v_src(2*n), v_src(2*n+1), v_src(2*n+swap_start), v_src(2*n+swap_start+1),
-                            ((self.sst_base + sst_offset)//(8*64))+2*n*(self.vec_stride//(8*64)), ((self.sst_base + sst_offset)//(8*64))+(2*n+1)*(self.vec_stride//(8*64))))
-            return self._get_deferred()
-
-        def likely_emit():
-            if self.vec_byte == 1:
-                if self.likely_write2_b32():
-                    return emit_write2_b32()
-                if self.likely_write2st64_b32():
-                    return emit_write2st64_b32()
-                return emit_write2_fallback()
-            if self.vec_byte == 2:
-                if self.likely_write2_b64():
-                    return emit_write2_b64()
-                if self.likely_write2st64_b64():
-                    return emit_write2st64_b64()
-                return emit_write2_fallback()
-            return emit_write2_fallback()
-
-        return likely_emit()
-    def emit(self):
-        assert False, 'dont use emit of this'
-    def get_issues(self):
-        if self.vec_byte == 1:
-            if self.likely_write2_b32() or self.likely_write2st64_b32():
-                return self.vec_count // 2
-        if self.vec_byte == 2:
-            if self.likely_write2_b64() or self.likely_write2st64_b64():
-                return self.vec_count // 2
-        return self.vec_count
-'''
 
 class inst_ds_write2_likely_t(mc_base_t):   
     def name(self):
@@ -551,6 +422,7 @@ class inst_ds_write2_likely_t(mc_base_t):
         self.vec_byte     = vector * data_byte
         self.vec_stride   = vec_stride
         self.sst_base     = sst_base
+        self.issues = 0
     def likely_write2_b32(self, sst_offset = 0):
         if self.vec_byte != 4:
             return False
@@ -595,10 +467,13 @@ class inst_ds_write2_likely_t(mc_base_t):
         def emit_write2_fallback(sst_offset = 0):
             #print(f"vec_byte={self.vec_byte}")
             #print(f"vec_count={self.vec_count}")
-            sstx1 = inst_ds_write_t(self.vec_byte)
+            if self.data_byte == 2: 
+               sstx1 = inst_ds_write_words_t(self.mc, self.vector)
+            else:
+               sstx1 = inst_ds_write_dwords_t(self.vector)
             with self._deferred_context():
                 for n in range(self.vec_count):
-                    self._emit(sstx1(v_sst(), v_src(n*(self.vec_byte // self.data_byte)), (self.sst_base + sst_offset) + n * self.vec_stride))
+                    self._emit(sstx1(v_sst(), v_src(n*self.vector), (self.sst_base + sst_offset) + n * self.vec_stride))
             return self._get_deferred()
 
         def emit_write2_b32(sst_offset = 0):
@@ -626,38 +501,38 @@ class inst_ds_write2_likely_t(mc_base_t):
             return self._get_deferred()
 
         def likely_emit(sst_offset = 0):
+            self.issues = self.vec_count
+            ## for fp16/bp16
+            if self.data_byte == 2:
+                if self.vector == 3: 
+                    self.issues = self.vec_count * 2
+                return emit_write2_fallback(sst_offset)
+
             if self.vec_byte == 4:
                 if self.likely_write2_b32(sst_offset):
+                    self.issues = self.vec_count // 2
                     return emit_write2_b32(sst_offset)
                 if self.likely_write2st64_b32(sst_offset):
+                    self.issues = self.vec_count // 2
                     return emit_write2st64_b32(sst_offset)
                 return emit_write2_fallback(sst_offset)
             if self.vec_byte == 8:
                 if self.likely_write2_b64(sst_offset):
+                    self.issues = self.vec_count // 2
                     return emit_write2_b64(sst_offset)
                 if self.likely_write2st64_b64(sst_offset):
+                    self.issues = self.vec_count // 2
                     return emit_write2st64_b64(sst_offset)
                 return emit_write2_fallback(sst_offset)
             return emit_write2_fallback(sst_offset)
         return likely_emit(sst_offset)
 
-    #def emit(self):
-    #    assert False, 'dont use emit of this'
-    def get_issues(self, sst_offset = 0):
-        if self.vec_byte == 4:
-            if self.likely_write2_b32(sst_offset) or self.likely_write2st64_b32(sst_offset):
-                return self.vec_count // 2
-        if self.vec_byte == 8:
-            if self.likely_write2_b64(sst_offset) or self.likely_write2st64_b64(sst_offset):
-                return self.vec_count // 2
-        return self.vec_count
-
+    def get_issues(self):
+        return self.issues
 
 class inst_ds_write2_likely_accumulate_offset_t(mc_base_t):   
     def name(self):
         return ''
-
-
 
 class inst_ds_read_t(object):
     def __init__(self, bytes):
@@ -674,12 +549,73 @@ class inst_ds_read_t(object):
         if self.bytes == 16:
             return 'ds_read_b128 v[{}:{}+3], v[{}] {}'.format(vdst, vdst, vaddr, self.get_offset(offset))
         assert False
-    def get_issues(self, sld_offset = 0):
+    def get_issues(self):
         return 1
 
-class inst_ds_write_t(object):
-    def __init__(self, bytes):
-        self.bytes = bytes
+class inst_ds_read_dwords_t(object):
+    def __init__(self, dwords):
+        self.dwords = dwords
+
+    def get_offset(self, offset):
+        return '' if offset == 0 else 'offset:{}'.format(offset)
+
+    def __call__(self, vdst, vaddr, offset):
+        print(f"dwords = {self.dwords}\n")
+        if self.dwords == 1:
+            return 'ds_read_b32 v[{}], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset))
+        if self.dwords == 2:
+            return 'ds_read_b64 v[{}:{}+1], v[{}] {}'.format(vdst, vdst, vaddr, self.get_offset(offset))
+        if self.dwords == 3:
+            return 'ds_read_b96 v[{}:{}+2], v[{}] {}'.format(vdst, vdst, vaddr, self.get_offset(offset))
+        if self.dwords == 4:
+            return 'ds_read_b128 v[{}:{}+3], v[{}] {}'.format(vdst, vdst, vaddr, self.get_offset(offset))
+        assert False
+
+    def get_issues(self):
+        return 1
+
+class inst_ds_read_words_t(mc_base_t):
+    def __init__(self, mc, words):
+        mc_base_t.__init__(self, mc)
+        self.words = words
+        self.issues = 1
+
+    def get_offset(self, offset):
+        return '' if offset == 0 else 'offset:{}'.format(offset)
+        assert False
+
+    ## assuming one vgpr will store only single word
+    def __call__(self, vdst, vaddr, offset = 0):
+        print(f"words = {self.words}\n")
+        with self._deferred_context():
+            if self.words == 1:
+                self._emit(f"v_mov_b32 v[{vdst}], 0")
+                self._emit('ds_read_u16_d16 v[{}], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset)))
+            if self.words == 2:
+                self._emit('ds_read_b32 v[{}], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset)))
+                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
+                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
+            if self.words == 3:
+                self._emit('ds_read_b32 v[{}], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset)))
+                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
+                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
+                self._emit(f"v_mov_b32 v[{vdst}+2], 0")
+                self._emit('ds_read_u16_d16 v[{}+2], v[{}] {}'.format(vdst, vaddr, self.get_offset(offset)))
+                self.issues = 2
+            if self.words == 4:
+                self._emit('ds_read_b64 v[{}:{}+1], v[{}] {}'.format(vdst, vdst, vaddr, self.get_offset(offset)))
+                self._emit(f"v_lshrrev_b32 v[{vdst}+3], 16, v[{vdst}+1]")
+                self._emit(f"v_and_b32 v[{vdst}+2], 0xffff, v[{vdst}+1]")
+                self._emit(f"v_lshrrev_b32 v[{vdst}+1], 16, v[{vdst}]")
+                self._emit(f"v_and_b32 v[{vdst}], 0xffff, v[{vdst}]")
+        return self._get_deferred()
+
+    def get_issues(self):
+        return self.issues 
+
+class inst_ds_write_dwords_t(object):
+    def __init__(self, dwords):
+        self.dwords = dwords
 
     def get_offset(self, offset):
         if type(offset) is str:
@@ -689,20 +625,59 @@ class inst_ds_write_t(object):
         assert False
 
     def __call__(self, vaddr, vdata, offset = 0):
-        if self.bytes == 2:
-            return 'ds_write_b16 v[{}], v[{}] {}'.format(vaddr, vdata, self.get_offset(offset))
-        if self.bytes == 4:
+        if self.dwords == 1:
             return 'ds_write_b32 v[{}], v[{}] {}'.format(vaddr, vdata, self.get_offset(offset))
-        if self.bytes == 8:
+        if self.dwords == 2:
             return 'ds_write_b64 v[{}], v[{}:{}+1] {}'.format(vaddr, vdata, vdata, self.get_offset(offset))
-        if self.bytes == 12:
+        if self.dwords == 3:
             return 'ds_write_b96 v[{}], v[{}:{}+2] {}'.format(vaddr, vdata, vdata, self.get_offset(offset))
-        if self.bytes == 16:
+        if self.dwords == 4:
             return 'ds_write_b128 v[{}], v[{}:{}+3] {}'.format(vaddr, vdata, vdata, self.get_offset(offset))
         assert False
 
-    def get_issues(self, sst_offset = 0):
+    def get_issues(self):
         return 1
+
+class inst_ds_write_words_t(mc_base_t):
+    def __init__(self, mc, words):
+        mc_base_t.__init__(self, mc)
+        self.words = words
+        self.issues = 1
+
+    def get_offset(self, offset):
+        return '' if offset == 0 else 'offset:{}'.format(offset)
+        assert False
+
+    ## assuming one vgpr stores only single word
+    def __call__(self, vaddr, vdata, offset = 0):
+        with self._deferred_context():
+            if self.words == 1:
+               self._emit('ds_write_b16 v[{}] v[{}] {}'.format(vaddr, vdata, self.get_offset(offset)))
+
+            if self.words == 2:
+                self._emit(f"v_lshlrev_b32 v[{vdata}+1], 16, v[{vdata}+1]")
+                self._emit(f"v_or_b32 v[{vdata}], v[{vdata}+1], v[{vdata}]") 
+                self._emit('ds_write_b32 v[{}] v[{}] {}'.format(vaddr, vdata, self.get_offset(offset)))
+
+            if self.words == 3:
+                self._emit(f"v_lshlrev_b32 v[{vdata}+1], 16, v[{vdata}+1]")
+                self._emit(f"v_or_b32 v[{vdata}], v[{vdata}+1], v[{vdata}]") 
+                self._emit('ds_write_b32 v[{}] v[{}] {}'.format(vaddr, vdata, self.get_offset(offset)))
+                self._emit('ds_write_b32 v[{}] v[{}+1] {}'.format(vaddr, vdata, self.get_offset(offset+4)))
+                issues = 2
+
+            if self.words == 4:
+                self._emit(f"v_lshlrev_b32 v[{vdata}+1], 16, v[{vdata}+1]")
+                self._emit(f"v_or_b32 v[{vdata}], v[{vdata}+1], v[{vdata}]")
+                self._emit(f"v_lshlrev_b32 v[{vdata}+3], 16, v[{vdata}+3]")
+                self._emit(f"v_or_b32 v[{vdata}+2], v[{vdata}+3], v[{vdata}+2]")
+                self._emit(f"v_mov_b32 v[{vdata}+1], v[{vdata}+2]")
+                self._emit('ds_write_b64 v[{}] v[{}:{}+1] {}'.format(vaddr, vdata, vdata, self.get_offset(offset)))
+
+        return self._get_deferred()
+
+    def get_issues(self):
+        return self.issues
 
 class ctrl_2d_shared_store_t(object):
     '''
@@ -756,121 +731,83 @@ class macro_igemm_2d_shared_store_t(macro_base_t):
 
     def expr(self):
         ctrl = self.ctrl
-        # assert ctrl.length_d1 == ctrl.vector_d1
-        # assert ctrl.precision == 'fp32', "TO BE supported"
-        # data_byte = amdgpu_precision_data_byte(ctrl.precision)
+        ##assert ctrl.precision == 'fp16', "TO BE supported"
         data_byte = ctrl.data_bytes
-        if ctrl.precision == 'fp32':
-            issue_cnt = 0
-            #print(f"{self.v_src()}")
-            #with self._emit_macro_indented('.macro {} v_src, v_sst_os'.format(self.name())):
-            if ctrl.length_d1 == ctrl.vector_d1:
-                if ctrl.src_order == 0 or (ctrl.src_order == 1 and ctrl.vector_d1 == 1):
-                    if ctrl.length_d0 % 2 == 0 and data_byte == 4 and ctrl.vector_d1 in (1, 2):
-                        ds_write2 = inst_ds_write2_likely_t(self.mc, 2, ctrl.vector_d1, data_byte, ctrl.stride_d0)
-                        for i_d0 in range(ctrl.length_d0 // 2):
-                            self._emit(ds_write2(f'{self.v_sst_os()}', f'{self.v_src()}+{2 * i_d0*ctrl.vector_d1}', 2 * i_d0 * ctrl.stride_d0))
-                            issue_cnt += ds_write2.get_issues(2 * i_d0 * ctrl.stride_d0)
-                    else:
-                        ds_write = inst_ds_write_t(ctrl.vector_d1 * data_byte)
-                        for i_d0 in range(ctrl.length_d0):
-                            self._emit(ds_write(f'{self.v_sst_os()}', f'{self.v_src()}+{i_d0*ctrl.vector_d1}', i_d0 * ctrl.stride_d0))
-                            issue_cnt += ds_write.get_issues()
+        issue_cnt = 0
+        if ctrl.length_d1 == ctrl.vector_d1:
+            if ctrl.src_order == 0 or (ctrl.src_order == 1 and ctrl.vector_d1 == 1):
+                if ctrl.length_d0 % 2 == 0 and data_byte == 4 and ctrl.vector_d1 in (1, 2):
+                    ds_write2 = inst_ds_write2_likely_t(self.mc, 2, ctrl.vector_d1, data_byte, ctrl.stride_d0)
+                    for i_d0 in range(ctrl.length_d0 // 2):
+                        self._emit(ds_write2(f'{self.v_sst_os()}', f'{self.v_src()}+{2 * i_d0*ctrl.vector_d1}', 2 * i_d0 * ctrl.stride_d0))
+                        issue_cnt += ds_write2.get_issues()
                 else:
-                    #if ctrl.length_d1 == 2 and ctrl.length_d0 in (2, 4, 6, 8):
-                    if ctrl.length_d1 == 2 and ctrl.length_d0 == 2:
-                        swap_sequencer = simple_swap_sequencer_t(ctrl.length_d0, ctrl.length_d1)
-                        swap_per_row = swap_sequencer.get_swap_per_row()
-                        start_id_per_row = swap_sequencer.get_start_id_per_row()
-    
-                        assert ctrl.length_d0 == len(swap_per_row) and ctrl.length_d0 == start_id_per_row
-    
-                        ds_write = inst_ds_write_t(ctrl.vector_d1 * data_byte)
-                        for i_d0 in range(ctrl.length_d0):
-                            swap = swap_per_row[i_d0]
-                            s_id = start_id_per_row[i_d0]
-                            if swap:
-                                self._emit(f"v_swap_b32 v[{self.v_src()}+{swap[0]}], v[{self.v_src()}+{swap[1]}]")
-                            self._emit(ds_write(f'{self.v_sst_os()}', f'{self.v_src()}+{s_id}', i_d0 * ctrl.stride_d0))
-                            issue_cnt += ds_write.get_issues()
-    
+                    if ctrl.precision == "fp32":
+                        ds_write = inst_ds_write_dwords_t(ctrl.vector_d1)
                     else:
-                        assert ctrl.v_tmp != None
-                        trans_seq = simple_transpose_sequencer_t(ctrl.length_d0, ctrl.length_d1)
-                        ds_write = inst_ds_write_t(ctrl.vector_d1 * data_byte)
-                        for i_d0 in range(ctrl.length_d0):
-                            s_id = trans_seq.get_start_id_per_row()[i_d0]
-                            for j in range(len(s_id)):
-                                self._emit(f"v_mov_b32 v[{ctrl.v_tmp(j)}], v[{self.v_src()}+{s_id[j]}]")
-                            self._emit(ds_write(f'{self.v_sst_os()}', f'{ctrl.v_tmp()}', i_d0 * ctrl.stride_d0))
-                            issue_cnt += ds_write.get_issues()
-            else:
-                assert ctrl.length_d1 % ctrl.vector_d1 == 0
-                assert ctrl.stride_d1 != 1
-                num_vector_d1 = ctrl.length_d1 // ctrl.vector_d1
-                # print(f"vector_d1={ctrl.vector_d1}, length_d1={ctrl.length_d1}")
-                ds_write2 = inst_ds_write2_likely_t(self.mc, 2, ctrl.vector_d1, data_byte, ctrl.stride_d1)
-                # print(f"ctrl.src_order={ctrl.src_order}")
-                if ctrl.src_order == 0:
-                    for i_d0 in range(ctrl.length_d0):
-                        for i_d1 in range(num_vector_d1 // 2):
-                            i_offset = i_d0 * ctrl.stride_d0 + 2* i_d1 * ctrl.stride_d1
-                            self._emit(ds_write2(f'{self.v_sst_os()}',
-                                    f'{self.v_src()}+{(i_d0 * ctrl.length_d1 + 2*i_d1)*ctrl.vector_d1}',
-                                    i_offset))
-                            issue_cnt += ds_write2.get_issues(i_offset)
-                else:
-                    # assert False, "this order, length_d1 and ctrl.vector_d1 has no means if not equal"
-                    # assert ctrl.v_tmp != None
-                    trans_seq = simple_transpose_sequencer_t(ctrl.length_d0, ctrl.length_d1)
-                    for i_d0 in range(ctrl.length_d0):
-                        s_id = trans_seq.get_start_id_per_row()[i_d0]
-                        # for j in range(len(s_id)):
-                        #     self._emit(f"v_mov_b32 v[{ctrl.v_tmp(j)}], v[{self.v_src()}+{s_id[j]}]")
-                        # for i_d1 in range(num_vector_d1 // 2):
-                        #     i_offset = i_d0 * ctrl.stride_d0 + 2* i_d1 * ctrl.stride_d1
-                        #     self._emit(ds_write2(f'{self.v_sst_os()}',
-                        #             ctrl.v_tmp(i_d1 * num_vector_d1 // 2),
-                        #             i_offset))
-                        #     issue_cnt += ds_write2.get_issues(i_offset)
-                        for i_d1 in range(num_vector_d1 // 2):
-                            i_offset = i_d0 * ctrl.stride_d0 + 2* i_d1 * ctrl.stride_d1
-                            self._emit(ds_write2(f'{self.v_sst_os()}',
-                                    (self.v_src(s_id[i_d1 * 2]), self.v_src(s_id[i_d1 * 2 + 1])),
-                                    i_offset))
-                            issue_cnt += ds_write2.get_issues(i_offset)
-        elif ctrl.precision in ('fp16', 'bf16'):
-            #print("under development")
-            issue_cnt = 0
-            if ctrl.length_d1 == ctrl.vector_d1:
-                if ctrl.src_order == 0 or (ctrl.src_order == 1 and ctrl.vector_d1 == 2):
-                    ds_write = inst_ds_write_t(ctrl.vector_d1 * data_byte)
+                        ds_write = inst_ds_write_words_t(self.mc, ctrl.vector_d1)
                     for i_d0 in range(ctrl.length_d0):
                         self._emit(ds_write(f'{self.v_sst_os()}', f'{self.v_src()}+{i_d0*ctrl.vector_d1}', i_d0 * ctrl.stride_d0))
                         issue_cnt += ds_write.get_issues()
-                else:
-                    assert False, "not support shared mem store"
             else:
-                assert ctrl.length_d1 % ctrl.vector_d1 == 0
-                assert ctrl.stride_d1 != 1
-                num_vector_d1 = ctrl.length_d1 // ctrl.vector_d1
-                #print(f"vector_d1={ctrl.vector_d1}, length_d1={ctrl.length_d1}")
-                ds_write2 = inst_ds_write2_likely_t(self.mc, 2, ctrl.vector_d1, data_byte, ctrl.stride_d1)
-                #print(f"ctrl.src_order={ctrl.src_order}")
-                if ctrl.src_order == 0:
+                #if ctrl.length_d1 == 2 and ctrl.length_d0 in (2, 4, 6, 8):
+                if ctrl.length_d1 == 2 and ctrl.length_d0 == 2:
+                    swap_sequencer = simple_swap_sequencer_t(ctrl.length_d0, ctrl.length_d1)
+                    swap_per_row = swap_sequencer.get_swap_per_row()
+                    start_id_per_row = swap_sequencer.get_start_id_per_row()
+
+                    assert ctrl.length_d0 == len(swap_per_row) and ctrl.length_d0 == start_id_per_row
+
+                    if ctrl.precision == "fp32":
+                        ds_write = inst_ds_write_dwords_t(ctrl.vector_d1)
+                    else:
+                        ds_write = inst_ds_write_words_t(self.mc, ctrl.vector_d1)
                     for i_d0 in range(ctrl.length_d0):
-                        for i_d1 in range(num_vector_d1 // 2):
-                            i_offset = i_d0 * ctrl.stride_d0 + 2* i_d1 * ctrl.stride_d1
-                            self._emit(ds_write2(f'{self.v_sst_os()}',
-                                    f'{self.v_src()}+{(i_d0 * ctrl.length_d1 + 2*i_d1)*ctrl.vector_d1}',
-                                    i_offset))
-                            issue_cnt += ds_write2.get_issues(i_offset)
+                        swap = swap_per_row[i_d0]
+                        s_id = start_id_per_row[i_d0]
+                        if swap:
+                            self._emit(f"v_swap_b32 v[{self.v_src()}+{swap[0]}], v[{self.v_src()}+{swap[1]}]")
+                        self._emit(ds_write(f'{self.v_sst_os()}', f'{self.v_src()}+{s_id}', i_d0 * ctrl.stride_d0))
+                        issue_cnt += ds_write.get_issues()
+
                 else:
-                    # assert False, "this order, length_d1 and ctrl.vector_d1 has no means if not equal"
-                    # assert ctrl.v_tmp != None
-                    assert False, "not support shared mem store, order==1"
+                    assert ctrl.v_tmp != None
+                    trans_seq = simple_transpose_sequencer_t(ctrl.length_d0, ctrl.length_d1)
+                    if ctrl.precision == "fp32":
+                        ds_write = inst_ds_write_dwords_t(ctrl.vector_d1)
+                    else:
+                        ds_write = inst_ds_write_words_t(self.mc, ctrl.vector_d1)
+                    for i_d0 in range(ctrl.length_d0):
+                        s_id = trans_seq.get_start_id_per_row()[i_d0]
+                        for j in range(len(s_id)):
+                            self._emit(f"v_mov_b32 v[{ctrl.v_tmp(j)}], v[{self.v_src()}+{s_id[j]}]")
+                        self._emit(ds_write(f'{self.v_sst_os()}', f'{ctrl.v_tmp()}', i_d0 * ctrl.stride_d0))
+                        issue_cnt += ds_write.get_issues()
         else:
-            pass
+            assert ctrl.length_d1 % ctrl.vector_d1 == 0
+            assert ctrl.stride_d1 != 1
+            num_vector_d1 = ctrl.length_d1 // ctrl.vector_d1
+            ds_write2 = inst_ds_write2_likely_t(self.mc, 2, ctrl.vector_d1, data_byte, ctrl.stride_d1)
+            if ctrl.src_order == 0:
+                for i_d0 in range(ctrl.length_d0):
+                    for i_d1 in range(num_vector_d1 // 2):
+                        i_offset = i_d0 * ctrl.stride_d0 + 2* i_d1 * ctrl.stride_d1
+                        self._emit(ds_write2(f'{self.v_sst_os()}',
+                                f'{self.v_src()}+{i_d0 * ctrl.length_d1 + 2*i_d1*ctrl.vector_d1}',
+                                i_offset))
+                        issue_cnt += ds_write2.get_issues()
+            else:
+                # assert False, "this order, length_d1 and ctrl.vector_d1 has no means if not equal"
+                # assert ctrl.v_tmp != None
+                trans_seq = simple_transpose_sequencer_t(ctrl.length_d0, ctrl.length_d1)
+                for i_d0 in range(ctrl.length_d0):
+                    s_id = trans_seq.get_start_id_per_row()[i_d0]
+                    for i_d1 in range(num_vector_d1 // 2):
+                        i_offset = i_d0 * ctrl.stride_d0 + 2* i_d1 * ctrl.stride_d1
+                        self._emit(ds_write2(f'{self.v_sst_os()}',
+                                (self.v_src(s_id[i_d1 * 2]), self.v_src(s_id[i_d1 * 2 + 1])),
+                                i_offset))
+                        issue_cnt += ds_write2.get_issues()
 
         self.issue_cnt = issue_cnt
 


### PR DESCRIPTION
The following changes are made by this PR:
1) global_load to support fp16/bp16 in global_memory.py
2) shared_store and shared_load to support fp16/bp16 in shared_memory.py
3) Corresponding changes in the main codes (igemm_fwd_gtc.py, igemm_bwd_gtc.py, igemm_fwd_gtc.py )
4) Changes in get_issues()

After the Changes:
1) fwd/bwd/wrw fp32 keep working correctly
2) The single config keep working correctly for fwd-fp16
