### PR TITLE
Fix a situation where shared_store should not transpose the thread slice

### DIFF
--- a/igemm/algo/igemm_fwd_gtc.py
+++ b/igemm/algo/igemm_fwd_gtc.py
@@ -954,6 +954,7 @@ class igemm_fwd_gtc_t(mc_base_t):
             else:
                 wei_sst_ctrl.length_d0 = wei_thread_copy_dims[wei_thread_copy_index[0]]
                 wei_sst_ctrl.length_d1 = wei_thread_copy_dims[wei_thread_copy_index[1]]
+                wei_sst_ctrl.need_transpose = 0
             if gemm_m_order == IGEMM_FWD_GTC_LDS_STORE_ORDER_GEMM_M_K0_K1:
                 wei_sst_ctrl.vector_d1 = ta_k1
             else:


### PR DESCRIPTION
This patch is for solving the configuration case where the thread copy dims for Wei is k0 and k1 ( both tensor_a_thread_lengths[2] and tensor_a_thread_lengths[3] are bigger than 1).  

The test case is :+1: 

#--------------------------- 64x64
[igemm_fwd_gtc]
gemm_m_per_block         = 64
gemm_n_per_block         = 64
gemm_k_per_block         = 64
wave_tile_m              = 16
wave_step_m              = 1
wave_repeat_m            = 2
wave_tile_n              = 16
wave_step_n              = 1
wave_repeat_n            = 2
tensor_a_thread_lengths  = [1, 1,  4, 4]       # C0xC1ExK0xK1
tensor_a_cluster_lengths = [1, 64, 1, 4]       # C0xC1ExK0xK1
##tensor_a_thread_lengths  = [1, 1,  16, 1]       # C0xC1ExK0xK1
##tensor_a_cluster_lengths = [1, 64, 1, 4]       # C0xC1ExK0xK1
tensor_b_thread_lengths  = [1, 16, 1, 1]       # C0xC1ExN0xN1B
tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
direction                = "fwd"
precision                = "fp32"
nxb                      = 1
nxe                      = 1 


The fix does not affect other successfully tested cases of fwd/bwd/wrw. 
