### PR TITLE
Mfma fp16 test

### DIFF
--- a/config/fp16-configs/tested/additional.config
+++ b/config/fp16-configs/tested/additional.config
@@ -1,0 +1,176 @@
+[codegen]
+arch = 'gfx908'
+code_object = 'cov3'
+mode = 'flat'
+
+# igemm_fwd_gtcx_nchw_fp16_bx1_ex0_bt32x128x32_wt8x32_ws1x1_wr2x2_ta1x4x1x1_1x8x1x32_tb1x16x1x1_1x2x1x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 32
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  16,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+# igemm_fwd_gtcx_nchw_fp16_bx1_ex0_bt128x64x32_wt32x8_ws1x2_wr2x2_ta1x4x1x4_1x8x1x32_tb1x8x1x1_1x4x1x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 32
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   4]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  8,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+# igemm_fwd_gtcx_nchw_fp16_bx1_ex1_bt128x64x32_wt32x8_ws1x2_wr2x2_ta1x4x1x4_1x8x1x32_tb1x8x1x1_1x4x1x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 32
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   4]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  8,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+# igemm_fwd_gtcx_nchw_fp16_bx1_ex0_bt64x64x64_wt16x16_ws1x1_wr2x2_ta1x4x1x4_1x16x1x16_tb1x16x1x1_1x4x1x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 64
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   4]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 16,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#-------------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 32
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   2]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 16,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+## added for supporting mask-rcnn
+#-------------------------------- 16x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16 
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1,  16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 16
+nxe                      = 0
+
+## added for supporting mask-rcnn
+#-------------------------------- 4x64 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16 
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  8,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 32
+nxe                      = 0
+
+## added for supporting mask-rcnn
+#-------------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 16,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  1,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 64 
+nxe                      = 0
+

--- a/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_0_nxb_1.config
+++ b/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_0_nxb_1.config
@@ -1,0 +1,4558 @@
+[codegen]
+arch = 'gfx908'
+code_object = 'cov3'
+mode = 'flat'
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1 
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,   8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4 , 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 16x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2 
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+##### The following configurations using one wave per work-group #####
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1 
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128 
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1 
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16 
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 0

--- a/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_0_nxb_4.config
+++ b/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_0_nxb_4.config
@@ -1,0 +1,4559 @@
+[codegen]
+arch = 'gfx908'
+code_object = 'cov3'
+mode = 'flat'
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4 
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,   8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4 , 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 16x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#### The following cases use two waves ####
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2 
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+##### The following configurations using one wave per work-group #####
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128 
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1 
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16 
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 0

--- a/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_1_nxb_1.config
+++ b/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_1_nxb_1.config
@@ -1,0 +1,4558 @@
+[codegen]
+arch = 'gfx908'
+code_object = 'cov3'
+mode = 'flat'
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1 
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,   8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4 , 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 16x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2 
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+##### The following configurations using one wave per work-group #####
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1 
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128 
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1 
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1                    
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16 
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 1
+nxe                      = 1

--- a/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_1_nxb_4.config
+++ b/config/fp16-configs/tested/igemm_fwd_gtc_gfx908_nxe_1_nxb_4.config
@@ -1,0 +1,4559 @@
+[codegen]
+arch = 'gfx908'
+code_object = 'cov3'
+mode = 'flat'
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4 
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 2, 4, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 8, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 2, 1, 128]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 8
+tensor_a_thread_lengths  = [1, 1,  8, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 4, 1, 64]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,   8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2     
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128 
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 128x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 128
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4 , 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 16x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#### The following cases use two waves ####
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2 
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 16x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 16
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1,  128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 256x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 256
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,   1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,   1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x128 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16 
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+##### The following configurations using one wave per work-group #####
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256 
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8 
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 4
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32 
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 1, 4, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 32, 1, 8]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 2, 2, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 32
+gemm_k_per_block         = 32
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 16
+tensor_a_thread_lengths  = [1, 2,  2, 1]       # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16, 1, 16]       # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1, 4, 1, 1]       # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 8, 1, 32]       # C0xC1ExN0xN1B
+direction                = "fwd"
+precision                = "fp16"
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 32x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 32
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 1
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]     # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 4x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 4
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128 
+gemm_k_per_block         = 16
+wave_tile_m              = 8 
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 16
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8 
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x128
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 128
+gemm_k_per_block         = 8
+wave_tile_m              = 8
+wave_step_m              = 2
+wave_repeat_m            = 2
+wave_tile_n              = 32
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 16
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x16
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 16
+gemm_k_per_block         = 8
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  2,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16 
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]     # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  16, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x256
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 256
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  2,  1, 128]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 16
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8 
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x32
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 32
+gemm_k_per_block         = 8
+wave_tile_m              = 32
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 8
+wave_step_n              = 2
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x4
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 4
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1, 16,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  4]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1, 16]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  4,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1, 16]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8 
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  8,  1, 32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 64
+gemm_k_per_block         = 8
+wave_tile_m              = 16
+wave_step_m              = 1
+wave_repeat_m            = 2
+wave_tile_n              = 16
+wave_step_n              = 1
+wave_repeat_n            = 2
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  2,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1, 64]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 64x8
+[igemm_fwd_gtc]
+gemm_m_per_block         = 64
+gemm_n_per_block         = 8
+gemm_k_per_block         = 16 
+wave_tile_m              = 64
+wave_step_m              = 1
+wave_repeat_m            = 1 
+wave_tile_n              = 4
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  8,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  16, 1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4                    
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16 
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  1,  8, 1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1
+
+#--------------------------- 8x64
+[igemm_fwd_gtc]
+gemm_m_per_block         = 8
+gemm_n_per_block         = 64
+gemm_k_per_block         = 16
+wave_tile_m              = 4
+wave_step_m              = 1
+wave_repeat_m            = 1
+wave_tile_n              = 64
+wave_step_n              = 1
+wave_repeat_n            = 1
+wave_tile_k              = 4
+tensor_a_thread_lengths  = [1,  1,  1,  1]      # C0xC1ExK0xK1
+tensor_a_cluster_lengths = [1, 16,  1,  8]      # C0xC1ExK0xK1
+tensor_b_thread_lengths  = [1,  4,  2,  1]      # C0xC1ExN0xN1B
+tensor_b_cluster_lengths = [1,  4,  1,  32]      # C0xC1ExN0xN1B
+direction                = 'fwd'
+precision                = 'fp16'
+nxb                      = 4
+nxe                      = 1

--- a/igemm/algo/igemm_base.py
+++ b/igemm/algo/igemm_base.py
@@ -273,7 +273,7 @@ class igemm_gtc_tunable_parameter_t(object):
         elif self.fma_type == IGEMM_GTC_TUNABLE_FMA_TYPE_XDLOPS:
             self.local_prefetch_num             = 2 if IGEMM_GTC_FEAT_LOCAL_PREFETCH else 1
             # register for a,b,c buffer
-            xdlops_mapping                      = get_ctrl_xdlops_mapping(self.gemm_m_per_block, self.gemm_n_per_block, self.precision, self.block_size // AMDGPU_WAVE_SIZE)
+            xdlops_mapping                      = get_ctrl_xdlops_mapping(self.gemm_m_per_block, self.gemm_n_per_block, self.wave_tile_m, self.wave_tile_n, self.precision, self.block_size // AMDGPU_WAVE_SIZE)
             self.num_agpr_accumulate_c          = xdlops_mapping.total_acc_c()
             assert self.num_agpr_accumulate_c == self.gemm_m_per_block * self.gemm_n_per_block // self.block_size
             self.num_vgpr_accumulate_a          = self.wave_step_m * self.wave_repeat_m * xdlops_mapping.inst_mfma.num_v_a * self.local_prefetch_num
@@ -312,7 +312,7 @@ class igemm_gtc_tunable_parameter_t(object):
         #    self.coalescing_store_groups = 2
         if self.fma_type == IGEMM_GTC_TUNABLE_FMA_TYPE_XDLOPS:
             # check on grouping
-            xdlops_mapping                      = get_ctrl_xdlops_mapping(self.gemm_m_per_block, self.gemm_n_per_block, self.precision, self.block_size // AMDGPU_WAVE_SIZE)
+            xdlops_mapping                      = get_ctrl_xdlops_mapping(self.gemm_m_per_block, self.gemm_n_per_block, self.wave_tile_m, self.wave_tile_n, self.precision, self.block_size // AMDGPU_WAVE_SIZE)
             length_in_m =  xdlops_mapping.wave_repeat_m * xdlops_mapping.wave_step_m * xdlops_mapping.lanegroup_m_per_wave() * xdlops_mapping.lanegroup_m_per_block() # no need xdlops_mapping.lanegroup_m_per_thread()
             if length_in_m % self.coalescing_store_groups != 0:
                 # we still asume both value are power of 2

--- a/igemm/algo/igemm_fwd_gtc.py
+++ b/igemm/algo/igemm_fwd_gtc.py
@@ -975,10 +975,10 @@ class igemm_fwd_gtc_t(mc_base_t):
                 wei_sst_ctrl.length_d0 = wei_thread_copy_dims[wei_thread_copy_index[0]]
                 wei_sst_ctrl.length_d1 = wei_thread_copy_dims[wei_thread_copy_index[1]]
             if gemm_m_order == IGEMM_FWD_GTC_LDS_STORE_ORDER_GEMM_M_K0_K1:
-                wei_sst_ctrl.vector_d1 = ta_k1 * sst_gemm_k_pack
+                wei_sst_ctrl.vector_d1 = math.gcd(ta_k1 * sst_gemm_k_pack, 4)
             else:
                 assert False, "to be implement"
-                wei_sst_ctrl.vector_d1 = wei_thread_copy_dims[wei_thread_copy_index[0]]
+                wei_sst_ctrl.vector_d1 = math.gcd(wei_thread_copy_dims[wei_thread_copy_index[0]], 4)
 
             if wei_thread_copy_index[0] in (0, 1) and wei_thread_copy_index[1] in (2, 3):
                 wei_sst_ctrl.stride_d0 = wei_stride_list[wei_thread_copy_index[1]] * data_byte * self.tunable.gemm_k_pack

--- a/igemm/algo/xdlops_mapping.py
+++ b/igemm/algo/xdlops_mapping.py
@@ -379,7 +379,7 @@ ctrl_xdlops_mapping_fp16 = [
         ctrl_xdlops_mapping_t( 4  , 64,  4 ,  64,   4, 1,  1,  1,  1,  1,  v_mfma_f32_4x4x4f16),
         ctrl_xdlops_mapping_t( 16 , 16,  16,  16,   4, 1,  1,  1,  1,  1,  v_mfma_f32_4x4x4f16)]
 
-def get_ctrl_xdlops_mapping(macro_tile_m, macro_tile_n, precision, waves = 4):
+def get_ctrl_xdlops_mapping(macro_tile_m, macro_tile_n, wave_tile_m, wave_tile_n, precision, waves = 4):
     if type(precision) is str:
         precision = amdgpu_string_to_precision(precision)
     ctrl_xdlops_mapping = ctrl_xdlops_mapping_fp32
@@ -394,7 +394,7 @@ def get_ctrl_xdlops_mapping(macro_tile_m, macro_tile_n, precision, waves = 4):
 
     target_mfma_tiling = list()
     for t in ctrl_xdlops_mapping:
-        if t.macro_tile_m == macro_tile_m and t.macro_tile_n == macro_tile_n and t.waves == waves:
+        if t.macro_tile_m == macro_tile_m and t.macro_tile_n == macro_tile_n and t.wave_tile_m == wave_tile_m and t.wave_tile_n == wave_tile_n and t.waves == waves:
             target_mfma_tiling.append(t)
 
     assert len(target_mfma_tiling) != 0, f"unsupported macro_tile_m:{macro_tile_m}, macro_tile_n:{macro_tile_n}, waves:{waves}"


### PR DESCRIPTION
Three commits:
1) Fix the inaccurate matching of xdlops mapping 
2) Fix the too-bigger vector_d1  size which causes failure of some configs
3) Load all configurations adapted from the fp32 original configurations (without tailoring)

