### PR TITLE
gemm-m padding support for bwd/wrw

### DIFF
--- a/driver/igemm_bwd_gtc_driver.h
+++ b/driver/igemm_bwd_gtc_driver.h
@@ -373,7 +373,6 @@ public:
         int w_tilda_slice = w_tilda_right - w_tilda_left;
         int num_of_gemm = y_tilda * x_tilda;
 
-        int gemm_m = c / group;
         int nxe = tunable->nxe;
         int nxb = tunable->nxb;
         int b = h_tilda_slice * w_tilda_slice;
@@ -382,7 +381,7 @@ public:
 
         bool unit_conv = (x==1)&&(y==1)&&(stride_h==1)&&(stride_w==1)&&(dilation_h==1)&&(dilation_w==1)&&(pad_h==0)&&(pad_w==0);
 
-        if((gemm_n%gemm_n_per_block!=0)||(gemm_m%gemm_m_per_block!=0)){
+        if(gemm_n%gemm_n_per_block!=0){
             // printf("tunable_is_valid false:: gemm_n is %d, gemm_n_per_block is %d, gemm_m is %d, gemm_m_per_block is %d\n", gemm_n,gemm_n_per_block,gemm_m,gemm_m_per_block);
             return false;
         }

--- a/driver/igemm_wrw_gtc_driver.h
+++ b/driver/igemm_wrw_gtc_driver.h
@@ -260,7 +260,6 @@ public:
 
         int n_per_block = n >> gemm_k_global_split;
 
-        int gemm_m = k / group;
         int gemm_n = (c / group) * y * x;
         int gemm_k = n * b;
 
@@ -271,8 +270,7 @@ public:
         {
             return false;
         }
-
-        if ((gemm_m % gemm_m_per_block !=0 ) || (gemm_k % gemm_k_per_block != 0)){
+        if (gemm_k % gemm_k_per_block != 0){
             //std::cout << __func__ << " false: gemm_n is " << gemm_n << ", gemm_n_per_block is " << gemm_n_per_block << ", gemm_m is " << gemm_m << ", gemm_m_per_block is " << gemm_m_per_block << std::endl;
             return false;
         }
@@ -534,7 +532,7 @@ public:
                         gemm_n_per_block = 1 << r;
                     }
                     
-                    if (gemm_m % gemm_m_per_block != 0 || gemm_n % gemm_n_per_block != 0)
+                    if (gemm_n % gemm_n_per_block != 0)
                         continue;
                     for (j = 5; j > 1; j--){
                         gemm_k_per_block = 1 << j;
@@ -572,7 +570,7 @@ public:
                             continue;
 
                         int log2_gemm_k_splits = 0;
-                        int grid_size = group * gemm_m / gemm_m_per_block * gemm_n / gemm_n_per_block;
+                        int grid_size = group * utility_integer_divide_ceil(gemm_m, gemm_m_per_block) * gemm_n / gemm_n_per_block;
                         for (int gs = 0; gs < 8; gs++){
                             if ((grid_size << gs) > 1200)
                                 break;


### PR DESCRIPTION
Hi All,
Gemm-m padding for fwd/bwd/wrw has been finished, good news is that we extend the applicability, and gain perf improvement as well.

Here’s the summary of the perf improvement:

Convolution   path | Improved   Ratio | Avrg(Improved   efficy-diff)
-- | -- | --
fwd | 24/144 | 9.5%
bwd | 31/144 | 9%
wrw | 38/144 | 12%

