### PR TITLE
split kernel into individual .s file

### DIFF
--- a/driver/conv_driver.cpp
+++ b/driver/conv_driver.cpp
@@ -694,7 +694,9 @@ int main(int argc, char **argv) {
     // printf("tunables:%d, hsaco:%s\n", tunables.size(), hsaco);
 
     hipModule_t module;
+#ifndef IGEMM_SPLIT_KERNEL
     HIP_CALL(hipModuleLoad(&module, hsaco));
+#endif
 
     std::string base_arg = create_base_args(argc, argv);
     args_t conv_args = create_conv_args(argc, argv);

--- a/driver/igemm_bwd_gtc_driver.h
+++ b/driver/igemm_bwd_gtc_driver.h
@@ -751,8 +751,14 @@ public:
         hipFunction_t kernel_func;
         std::string kernel_name = get_kernel_name(tunable);
         // printf("kernel:%s\n, block:%d, grid:%d\n", kernel_name.c_str(), block_size, grid_size);
-        HIP_CALL(
-            hipModuleGetFunction(&kernel_func, module, kernel_name.c_str()));
+#ifdef IGEMM_SPLIT_KERNEL
+        hipModule_t cur_kernel_module;
+        std::string cur_kernel_hsaco = kernel_name + ".hsaco";
+        HIP_CALL(hipModuleLoad(&cur_kernel_module, cur_kernel_hsaco.c_str()));
+        HIP_CALL(hipModuleGetFunction(&kernel_func, cur_kernel_module, kernel_name.c_str()));
+#else
+        HIP_CALL(hipModuleGetFunction(&kernel_func, module, kernel_name.c_str()));
+#endif
 
 #ifdef IGEMM_BWD_UPSAMPLING_USE_CUSTOM_KERNEL
         hipFunction_t upsampling_clear_kernel_func;
@@ -880,6 +886,9 @@ public:
             assert(0);
         }
 
+#ifdef IGEMM_SPLIT_KERNEL
+        HIP_CALL(hipModuleUnload(cur_kernel_module));
+#endif
         usleep(1000 * 5);
         return result;
     }

--- a/driver/igemm_fwd_gtc_driver.h
+++ b/driver/igemm_fwd_gtc_driver.h
@@ -611,7 +611,15 @@ public:
 
         hipFunction_t kernel_func;
         std::string kernel_name = get_kernel_name(tunable);
+
+#ifdef IGEMM_SPLIT_KERNEL
+        hipModule_t cur_kernel_module;
+        std::string cur_kernel_hsaco = kernel_name + ".hsaco";
+        HIP_CALL(hipModuleLoad(&cur_kernel_module, cur_kernel_hsaco.c_str()));
+        HIP_CALL(hipModuleGetFunction(&kernel_func, cur_kernel_module, kernel_name.c_str()));
+#else
         HIP_CALL(hipModuleGetFunction(&kernel_func, module, kernel_name.c_str()));
+#endif
 
         // TODO: use kernel to pre-clear when atomic
         auto fwd_prolog = tunable->gemm_k_global_split ? 
@@ -668,6 +676,9 @@ public:
             assert(0);
         }
 
+#ifdef IGEMM_SPLIT_KERNEL
+        HIP_CALL(hipModuleUnload(cur_kernel_module));
+#endif
         usleep(1000 * 5);
         return result;
     }

--- a/driver/igemm_gtc_base.h
+++ b/driver/igemm_gtc_base.h
@@ -573,7 +573,7 @@ public:
     virtual igemm_gtc_tunable_t heuristic_select_kernel(const args_t *arg) {return igemm_gtc_tunable_t{}; }
     virtual int heuristic_select_gks(const args_t *arg, const igemm_gtc_tunable_t *tunable) {return 0; }
 
-    hipModule_t         module;
+    hipModule_t         module;         // not used in IGEMM_SPLIT_KERNEL case
     driver_mode_t       driver_mode;
     driverDataType_t    data_type;
     int                 warmup;

--- a/driver/igemm_wrw_gtc_driver.h
+++ b/driver/igemm_wrw_gtc_driver.h
@@ -640,9 +640,14 @@ public:
         std::string kernel_name = get_kernel_name(tunable);
         //dump_wrw_karg(&karg);
         //printf("kernel:%s\n, block:%d, grid:%d, gemm_k_global_split:%d\n", kernel_name.c_str(), block_size, grid_size, gemm_k_global_split);
-        HIP_CALL(
-            hipModuleGetFunction(&kernel_func, module, kernel_name.c_str()));
-
+#ifdef IGEMM_SPLIT_KERNEL
+        hipModule_t cur_kernel_module;
+        std::string cur_kernel_hsaco = kernel_name + ".hsaco";
+        HIP_CALL(hipModuleLoad(&cur_kernel_module, cur_kernel_hsaco.c_str()));
+        HIP_CALL(hipModuleGetFunction(&kernel_func, cur_kernel_module, kernel_name.c_str()));
+#else
+        HIP_CALL(hipModuleGetFunction(&kernel_func, module, kernel_name.c_str()));
+#endif
         // hipMemset(p_wei, 0x0, group * (k / group) * (c / group) * y * x * sizeof(float));
 
         auto wrw_prolog = gemm_k_global_split ? 
@@ -664,6 +669,9 @@ public:
         result.gks         = gemm_k_global_split;
         result.kernel_name = kernel_name;
 
+#ifdef IGEMM_SPLIT_KERNEL
+        HIP_CALL(hipModuleUnload(cur_kernel_module));
+#endif
         return result;
     }
 };

--- a/igemm/igemm_codegen_driver.py
+++ b/igemm/igemm_codegen_driver.py
@@ -32,8 +32,10 @@ import os
 import copy
 import multiprocessing as mp
 
-IGEMM_EMIT_KERNEL_PER_INC_FILE = 1
+IGEMM_EMIT_KERNEL_PER_INC_FILE = 0
+IGEMM_EMIT_KERNEL_PER_S_FILE = 1
 IGEMM_EMIT_KERNEL_METADATA_PER_INC_FILE = 0     # it seems fail to find symbol if seperate metadata of different kernel using multiple .amdgpu_metadata
+IGEMM_EMIT_KERNEL_METADATA_PER_S_FILE = 1
 
 class igemm_codegen_driver_t(mc_base_t):
     def __init__(self, mc, tunable_dicts):
@@ -104,7 +106,30 @@ class igemm_codegen_driver_t(mc_base_t):
         if self.mc.arch_config.arch == AMDGPU_ARCH_GFX908 and self.mc.arch_config.use_xdlops:
             macro_acc_c_clear_t(self.mc).emit()
         macro_c_clear_t(self.mc).emit()
-        if self.mc.arch_config.arch == AMDGPU_ARCH_GFX908 and not self.mc.arch_config.use_dlops:
+        if self.mc.arch_config.use_dlops:
+            self._emit_fma_macro()
+
+    def emit_global_macro_per_s_file(self, mc):
+        # emit global macro, independent of tunable
+        if self.tunable_dicts[0]['direction'] == 'wrw':
+            macro_int_div_vv_t(mc).emit()
+            macro_int_div_vs_t(mc).emit()
+            macro_int_div_ss_t(mc).emit()
+            macro_int_div_rem_vv_t(mc).emit()
+            macro_int_div_rem_vs_t(mc).emit()
+            macro_int_div_rem_ss_t(mc).emit()
+
+        if IGEMM_GTC_FEAT_MAGIC_DIVISION:
+            macro_mdiv_u32_ss_t(mc).emit()
+            macro_mdiv_u32_rem_ss_t(mc).emit()
+            macro_mdiv_u32_vs_t(mc).emit()
+            macro_mdiv_u32_rem_vs_t(mc).emit()
+
+        # emit_write_4d_strided_t(self.mc).emit()
+        if self.mc.arch_config.arch == AMDGPU_ARCH_GFX908 and self.mc.arch_config.use_xdlops:
+            macro_acc_c_clear_t(mc).emit()
+        macro_c_clear_t(mc).emit()
+        if self.mc.arch_config.use_dlops:
             self._emit_fma_macro()
 
     def emit_igemm_macro(self):
@@ -126,13 +151,19 @@ class igemm_codegen_driver_t(mc_base_t):
             root_file_name = os.path.splitext(origin_file_name)[0]
             return root_file_name + f"_{ker.tunable.gemm_m_per_block:03}x{ker.tunable.gemm_n_per_block:03}x{ker.tunable.gemm_k_per_block:03}" + ".inc"
 
+        def get_kernel_per_s_file_name(ker, origin_file_name):
+            if type(ker) is igemm_upsampling_clear_t:
+                return os.path.join(os.path.dirname(origin_file_name), f"{ker.name()}.s")
+            root_file_name = os.path.dirname(origin_file_name)
+            return root_file_name + '/' + ker.name() + '.s'
+
         # emit the kernel
         #emit_v4r1_dynamic_kernel(self.mc, self.tunable_dicts)
-        if IGEMM_EMIT_KERNEL_PER_INC_FILE:
+        if IGEMM_EMIT_KERNEL_PER_INC_FILE or IGEMM_EMIT_KERNEL_PER_S_FILE:
             origin_emitter = self.mc.emitter
             assert type(origin_emitter) is mc_emit_to_file_t
             emitter_per_inc_dict = dict()
-            if IGEMM_EMIT_KERNEL_METADATA_PER_INC_FILE:
+            if IGEMM_EMIT_KERNEL_METADATA_PER_INC_FILE or IGEMM_EMIT_KERNEL_METADATA_PER_S_FILE:
                 kinfo_per_inc_dict = dict()
             self._emit_empty_line()
             self._emit(f";---------------------------------------------------")
@@ -214,6 +245,24 @@ class igemm_codegen_driver_t(mc_base_t):
                         if IGEMM_EMIT_KERNEL_METADATA_PER_INC_FILE:
                             kinfo_per_inc_dict[kpi_file_name].append(kernel.get_kernel_info())
 
+                elif IGEMM_EMIT_KERNEL_PER_S_FILE:
+                    kps_file_name = get_kernel_per_s_file_name(kernel, origin_emitter.file_name)
+                    if kps_file_name not in emitter_per_inc_dict:
+
+                        kps_emitter = mc_emit_to_file_t(kps_file_name, copy.copy(origin_emitter.indent))
+                        kernel.mc.emitter = kps_emitter
+                        kps_emitter.open()
+                        #kernel._emit(f".include \"{os.path.basename(origin_emitter.file_name)}\"")
+                        self.emit_global_macro_per_s_file(kernel.mc)
+
+                        emitter_per_inc_dict[kps_file_name] = kps_emitter
+                        if IGEMM_EMIT_KERNEL_METADATA_PER_S_FILE:
+                            kinfo_per_inc_dict[kps_file_name] = [kernel.get_kernel_info()]
+                    else:
+                        kernel.mc.emitter = emitter_per_inc_dict[kps_file_name]
+                        if IGEMM_EMIT_KERNEL_METADATA_PER_S_FILE:
+                            kinfo_per_inc_dict[kps_file_name].append(kernel.get_kernel_info())
+
                 if type(kernel) is not igemm_upsampling_clear_t:
                     kernel._emit(';----------------------------------------------------------')
                     kernel._emit('; starting of kernel {}'.format(kernel.name()))
@@ -241,6 +290,14 @@ class igemm_codegen_driver_t(mc_base_t):
             self.mc.emitter = origin_emitter
             self._emit(f";---------------------------------------------------")
             self._emit_empty_line()
+        elif IGEMM_EMIT_KERNEL_PER_S_FILE:
+            for k, v in emitter_per_inc_dict.items():
+                self.mc.emitter = emitter_per_inc_dict[k]
+                amdgpu_metadata_t(self.mc, kinfo_per_inc_dict[k]).emit()
+                # os.chmod(k, 0x777)
+                v.close()
+                self._emit(f";---------------------------------------------------")
+                self._emit_empty_line()
 
     def emit_metadata(self):
         kernel_info_list = [kernel.get_kernel_info() for kernel in self.kernel_list]

--- a/igemm_codegen.py
+++ b/igemm_codegen.py
@@ -47,7 +47,7 @@ def igemm_flatten(args, config_content):
     for td in tunable_dicts:
         td['arch'] = sec_root['arch']       # append arch to each section
 
-    igemm_codegen_driver_t(mc, tunable_dicts)()
+    igemm_codegen_driver_t(mc, tunable_dicts)(split_kernel = args.split_kernel)
 
     # os.chmod(asm_target, 0x777)
 
@@ -82,6 +82,7 @@ if __name__ == '__main__':
     parser.add_argument("config_file", help="config file as input")
     parser.add_argument("-d", "--dir", help="directory of output files", default = OUT_DIR)
     parser.add_argument("-output", nargs='?', const='tunable_parameter_list.txt', help="output tunable parameter list")
+    parser.add_argument("-s", "--split_kernel", action="store_true")
     args = parser.parse_args()
 
     config_parser = config_parser_t(args.config_file)
@@ -101,7 +102,10 @@ if __name__ == '__main__':
         if os.path.exists(args.dir):
             shutil.rmtree(args.dir)
         os.mkdir(args.dir)
-        igemm_host_driver(arch=arch, config_file=args.config_file, out_dir=args.dir, has_fp16_config=has_fp16_config, has_int8_config=has_int8_config)
+        cxxflags = []
+        if args.split_kernel:
+            cxxflags += ["-DIGEMM_SPLIT_KERNEL"]
+        igemm_host_driver(cxxflags=cxxflags, arch=arch, config_file=args.config_file, out_dir=args.dir, has_fp16_config=has_fp16_config, has_int8_config=has_int8_config)
         igemm_flatten(args, config_content)
 
     if config_content.get_section('codegen')[0]['mode'] in ('seq', 'sequencer'):


### PR DESCRIPTION
support `-s` command line while using igemm_codegen.py to generate each kernel into a single .s file.
e.g:
```
python3  igemm_codegen.py config/igemm_bwd_gtc_gfx908_nhwc.config     # every kernel in a single hsaco
python3 -s igemm_codegen.py config/igemm_bwd_gtc_gfx908_nhwc.config   # split kernel into individual hsaco
```

- support split kernel into each individual `.s` file
- support compile each each individual `.s` into multiple `.hsaco`
- support conv_driver use different kernel from corresponding `.hsaco`