### PR TITLE
Fix gcnArchName gfx942 and BFloat16

### DIFF
--- a/driver/conv_driver.cpp
+++ b/driver/conv_driver.cpp
@@ -137,13 +137,15 @@ static inline double get_theoritical_gpu_gflops(int sclk_mhz, driverDataType_t d
     HIP_CALL(hipGetDevice(&dev));
     HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
     num_cu = dev_prop.multiProcessorCount;
-    gcn_arch = dev_prop.gcnArch;
+    gcn_arch = get_gcn_arch(dev_prop.gcnArchName);
     if(gcn_arch >= 1000)
         num_cu *= 2;
 
     int fp_factor = 1;
     if(data_type == driverHalf){
-        if(gcn_arch == 908 || gcn_arch == 910)
+        if(gcn_arch == 942 || gcn_arch == 941 || gcn_arch == 940)
+            fp_factor = 8;  // xdlops
+        else if(gcn_arch == 908 || gcn_arch == 910)
             fp_factor = 4;  // xdlops
         else
             fp_factor = 2;  // dlops
@@ -151,7 +153,9 @@ static inline double get_theoritical_gpu_gflops(int sclk_mhz, driverDataType_t d
             fp_factor = 2;
     }
     if(data_type == driverInt8){
-        if(gcn_arch == 908 || gcn_arch == 910)
+        if(gcn_arch == 942 || gcn_arch == 941 || gcn_arch == 940)
+            fp_factor = 8;  // xdlops
+        else if(gcn_arch == 908 || gcn_arch == 910)
             fp_factor = 4;  // xdlops
         else
             fp_factor = 4;  // dlops
@@ -165,7 +169,7 @@ static inline double get_theoritical_gpu_gflops(int sclk_mhz, driverDataType_t d
     //     fp_factor = 4;
     // }
 
-    if(gcn_arch == 908 || gcn_arch == 910){
+    if(gcn_arch == 908 || gcn_arch == 910 || gcn_arch == 942 || gcn_arch == 941 || gcn_arch == 940){
         num_simd = 4 * 32 ; // 4x miSIMD, 32x mac unit
     }
 

--- a/driver/igemm_gtc_base.h
+++ b/driver/igemm_gtc_base.h
@@ -152,10 +152,10 @@ static inline std::string get_igemm_gtc_fma_type(std::string arch_string, const 
             return IGEMM_GTC_TUNABLE_FMA_TYPE_MAC;
         if(arch_string == "gfx906" || arch_string == "gfx1030")
             return IGEMM_GTC_TUNABLE_FMA_TYPE_DLOPS;
-        if(arch_string == "gfx908" || arch_string == "gfx90a" || arch_string == "gfx940")
+        if(arch_string == "gfx908" || arch_string == "gfx90a" || arch_string == "gfx940" || arch_string == "gfx942")
             return IGEMM_GTC_TUNABLE_FMA_TYPE_DLOPS;
     }else if(sec.count("wave_tile_m") > 0 && sec.count("wave_tile_n") > 0){
-        assert(arch_string == "gfx908" || arch_string == "gfx90a" || arch_string == "gfx940");
+        assert(arch_string == "gfx908" || arch_string == "gfx90a" || arch_string == "gfx940" || arch_string == "gfx942");
         return IGEMM_GTC_TUNABLE_FMA_TYPE_XDLOPS;
     }
     return IGEMM_GTC_TUNABLE_FMA_TYPE_NA;
@@ -229,6 +229,27 @@ igemm_gtc_tunable_from_config(const config_content_t &content) {
     return tunables;
 }
 
+static inline int get_gcn_arch(char* archname)
+{
+    int gcn_arch = 1000;
+    if (!strncmp("gfx908", archname, 6)){
+        gcn_arch = 908;
+    }
+    else if (!strncmp("gfx90a", archname, 6)){
+        gcn_arch = 910;
+    }
+    else if (!strncmp("gfx940", archname, 6)){
+        gcn_arch = 940;
+    }
+    else if (!strncmp("gfx941", archname, 6)){
+        gcn_arch = 941;
+    }
+    else if (!strncmp("gfx942", archname, 6)){
+        gcn_arch = 942;
+    }
+    return gcn_arch;
+}
+
 static inline std::string
 igemm_gtc_encode_kernel_name(const igemm_gtc_tunable_t *tunable) {
     auto tensor_layout            = tunable->tensor_layout;
@@ -267,7 +288,7 @@ igemm_gtc_encode_kernel_name(const igemm_gtc_tunable_t *tunable) {
         hipDevice_t dev;
         HIP_CALL(hipGetDevice(&dev));
         HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
-        gcn_arch = dev_prop.gcnArch;
+        gcn_arch = get_gcn_arch(dev_prop.gcnArchName);
     }
 
     std::string kernel_name = std::string("igemm_") + direction + "_";
@@ -283,7 +304,7 @@ igemm_gtc_encode_kernel_name(const igemm_gtc_tunable_t *tunable) {
             kernel_name += "gtcx_";
         else if(gcn_arch == 910)
             kernel_name += "gtcx2_";
-        else if(gcn_arch == 940)
+        else if(gcn_arch == 940 || gcn_arch == 941 || gcn_arch == 942)
             kernel_name += "gtcx3_";
     }
     std::string vector_c_str = "";
@@ -602,7 +623,7 @@ public:
         HIP_CALL(hipGetDevice(&dev));
         HIP_CALL(hipGetDeviceProperties(&dev_prop, dev));
         this->num_cu = dev_prop.multiProcessorCount;
-        this->gcn_arch = dev_prop.gcnArch;
+        gcn_arch = get_gcn_arch(dev_prop.gcnArchName);
         if(this->gcn_arch >= 1000)
             this->num_cu *= 2;
         max_mpb = -1;

--- a/driver/tensor_validation_cpu.h
+++ b/driver/tensor_validation_cpu.h
@@ -261,6 +261,13 @@ double get_nrms(std::string direction, driverDataType_t driver_data_type){
             return 8.2e-3;
 #endif
         }
+        else if (driver_data_type == driverBFloat16){
+#ifdef USE_XDNN
+            return 5*8.2e-3;
+#else
+            return 8.2e-3;
+#endif
+        }
     };
     double nrms = basic_tolerance();
     if (direction == "bwd"){
@@ -273,6 +280,9 @@ double get_nrms(std::string direction, driverDataType_t driver_data_type){
             nrms = 0.01;
         }
         else if(driver_data_type == driverHalf){
+            nrms *= 5;
+        }
+        else if(driver_data_type == driverBFloat16){
             nrms *= 5;
         }
     }

--- a/python/codegen/amdgpu.py
+++ b/python/codegen/amdgpu.py
@@ -46,6 +46,7 @@ AMDGPU_ARCH_GFX906      = 906
 AMDGPU_ARCH_GFX908      = 908
 AMDGPU_ARCH_GFX90A      = 910
 AMDGPU_ARCH_GFX940      = 940
+AMDGPU_ARCH_GFX942      = 942
 AMDGPU_ARCH_GFX1030     = 1030
 
 AMDGPU_WAVE_SIZE        = 64
@@ -73,6 +74,8 @@ def amdgpu_string_to_arch(amdgpu_arch_string):
         return AMDGPU_ARCH_GFX90A
     if amdgpu_arch_string == 'gfx940':
         return AMDGPU_ARCH_GFX940
+    if amdgpu_arch_string == 'gfx942':
+        return AMDGPU_ARCH_GFX942
     if amdgpu_arch_string == 'gfx1030':
         return AMDGPU_ARCH_GFX1030
     assert False
@@ -88,6 +91,8 @@ def amdgpu_arch_to_string(amdgpu_arch_gfxxxx):
         return 'gfx90a'
     if amdgpu_arch_gfxxxx == AMDGPU_ARCH_GFX940:
         return 'gfx940'
+    if amdgpu_arch_gfxxxx == AMDGPU_ARCH_GFX942:
+        return 'gfx942'
     if amdgpu_arch_gfxxxx == AMDGPU_ARCH_GFX1030:
         return 'gfx1030'
     assert False
@@ -282,7 +287,7 @@ class amdgpu_arch_config_t(object):
         if self.arch == AMDGPU_ARCH_GFX906:
             self.use_dlops  = ad('use_dlops', True)
             self.use_xdlops = ad('use_xdlops', False)
-        elif self.arch in (AMDGPU_ARCH_GFX908, AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940):
+        elif self.arch in (AMDGPU_ARCH_GFX908, AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940, AMDGPU_ARCH_GFX942):
             self.use_dlops  = ad('use_dlops', False)
             self.use_xdlops = ad('use_xdlops', True)
         elif self.arch == AMDGPU_ARCH_GFX1030:
@@ -537,7 +542,7 @@ class amd_kernel_code_t(mc_base_t):
                     self._emit('.amdhsa_float_denorm_mode_16_64 {}'.format(         self.ki.kernel_code.amdhsa_float_denorm_mode_16_64))
                 if self.ki.kernel_code.amdhsa_fp16_overflow:
                     self._emit('.amdhsa_fp16_overflow {}'.format(                   self.ki.kernel_code.amdhsa_fp16_overflow))
-                if self.mc.arch_config.arch in (AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940):
+                if self.mc.arch_config.arch in (AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940, AMDGPU_ARCH_GFX942):
                     self._emit('.amdhsa_tg_split {}'.format(                        self.ki.kernel_code.tg_split))
                     self._emit('.amdhsa_accum_offset {}'.format(                    self.ki.kernel_code.accum_offset))
                 if self.mc.arch_config.arch >= 1000:

--- a/python/codegen_driver.py
+++ b/python/codegen_driver.py
@@ -135,7 +135,7 @@ class codegen_driver_t(mc_base_t):
             macro_mdiv_u32_rem_vs_t(self.mc).emit()
 
         # emit_write_4d_strided_t(self.mc).emit()
-        if self.mc.arch_config.arch in (AMDGPU_ARCH_GFX908, AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940) and self.mc.arch_config.use_xdlops:
+        if self.mc.arch_config.arch in (AMDGPU_ARCH_GFX908, AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940, AMDGPU_ARCH_GFX942) and self.mc.arch_config.use_xdlops:
             macro_acc_c_clear_t(self.mc).emit()
         macro_c_clear_t(self.mc).emit()
         if self.mc.arch_config.arch == AMDGPU_ARCH_GFX1030:
@@ -157,7 +157,7 @@ class codegen_driver_t(mc_base_t):
                 dfv = self.kernel_list[0].get_predefine_for_bf16_1k_in_fp16_default_value()
                 inst_mfma_emit_macro_mfma_16f(self.mc, sym, dfv)
 
-        if self.mc.arch_config.arch == AMDGPU_ARCH_GFX940:
+        if self.mc.arch_config.arch == AMDGPU_ARCH_GFX940 or self.mc.arch_config.arch == AMDGPU_ARCH_GFX942:
             inst_buffer_store_emit_with_macro(self.mc)
             inst_buffer_atomic_add_emit_with_macro(self.mc)
 
@@ -181,7 +181,7 @@ class codegen_driver_t(mc_base_t):
             macro_mdiv_u32_rem_vs_t(mc).emit()
 
         # emit_write_4d_strided_t(self.mc).emit()
-        if self.mc.arch_config.arch in (AMDGPU_ARCH_GFX908, AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940) and self.mc.arch_config.use_xdlops:
+        if self.mc.arch_config.arch in (AMDGPU_ARCH_GFX908, AMDGPU_ARCH_GFX90A, AMDGPU_ARCH_GFX940, AMDGPU_ARCH_GFX942) and self.mc.arch_config.use_xdlops:
             macro_acc_c_clear_t(mc).emit()
         macro_c_clear_t(mc).emit()
         if self.mc.arch_config.arch == AMDGPU_ARCH_GFX1030:

--- a/python/igemm/igemm_base.py
+++ b/python/igemm/igemm_base.py
@@ -128,10 +128,10 @@ def get_igemm_gtc_fma_type(tunable_dict):
     if 'gemm_m_per_thread' in tunable_dict and 'gemm_n_per_thread' in tunable_dict:
         if tunable_dict['arch'] == 'gfx900':
             return IGEMM_GTC_TUNABLE_FMA_TYPE_MAC
-        if tunable_dict['arch'] in ('gfx906', 'gfx908', 'gfx90a', 'gfx940', 'gfx1030'):
+        if tunable_dict['arch'] in ('gfx906', 'gfx908', 'gfx90a', 'gfx940', 'gfx942', 'gfx1030'):
             return IGEMM_GTC_TUNABLE_FMA_TYPE_DLOPS
     if 'wave_tile_m' in tunable_dict and 'wave_tile_n' in tunable_dict:
-        assert tunable_dict['arch'] in ('gfx908', 'gfx90a', 'gfx940')
+        assert tunable_dict['arch'] in ('gfx908', 'gfx90a', 'gfx940', 'gfx942')
         return IGEMM_GTC_TUNABLE_FMA_TYPE_XDLOPS
     if 'lanegroup_tile_m' in tunable_dict and 'lanegroup_tile_n' in tunable_dict:
         return IGEMM_GTC_TUNABLE_FMA_TYPE_DLOPS
@@ -139,7 +139,7 @@ def get_igemm_gtc_fma_type(tunable_dict):
 
 def get_igemm_gtc_gemm_k_global_split(tunable_dict):
     assert type(tunable_dict) is dict
-    if tunable_dict['arch'] in ('gfx908', 'gfx90a', 'gfx940'):
+    if tunable_dict['arch'] in ('gfx908', 'gfx90a', 'gfx940', 'gfx942'):
         gemm_k_global_split = utility_dict_with_default_t(tunable_dict)('gemm_k_global_split', 0)
         if gemm_k_global_split > 0:
             return 1
@@ -749,7 +749,7 @@ def igemm_gtc_encode_kernel_base_name(tunable, arch):
             kernel_name += 'gtcx_'                              # generic tensor contraction with xdlops
         elif arch_str == 'gfx90a':
             kernel_name += 'gtcx2_'
-        elif arch_str == 'gfx940':
+        elif arch_str == 'gfx940' or arch_str == 'gfx942':
             kernel_name += 'gtcx3_'
         else:
             assert False

--- a/python/operations/coalescing_store.py
+++ b/python/operations/coalescing_store.py
@@ -1178,9 +1178,9 @@ class igemm_coalescing_store_xdlops_t(mc_base_t):
         inst_sld = inst_ds_read_t(inst_sld_byte)
         if ctrl.gemm_k_global_split:
             v_pack = 2 if ctrl.vector_write_out == 2 and data_byte == 2 else 1
-            inst_gst = inst_buffer_atomic_add_dword_with_macro_switch_t(ctrl.vector_write_out * data_byte, v_pack) if self.mc.arch_config.arch == AMDGPU_ARCH_GFX940 else inst_buffer_atomic_add_dword_t(ctrl.vector_write_out * data_byte, v_pack) 
+            inst_gst = inst_buffer_atomic_add_dword_with_macro_switch_t(ctrl.vector_write_out * data_byte, v_pack) if self.mc.arch_config.arch == AMDGPU_ARCH_GFX940 or self.mc.arch_config.arch == AMDGPU_ARCH_GFX942 else inst_buffer_atomic_add_dword_t(ctrl.vector_write_out * data_byte, v_pack)
         else:
-            inst_gst = inst_buffer_store_with_macro_switch_t(ctrl.vector_write_out * data_byte) if self.mc.arch_config.arch == AMDGPU_ARCH_GFX940 else inst_buffer_store_t(ctrl.vector_write_out * data_byte)
+            inst_gst = inst_buffer_store_with_macro_switch_t(ctrl.vector_write_out * data_byte) if self.mc.arch_config.arch == AMDGPU_ARCH_GFX940 or self.mc.arch_config.arch == AMDGPU_ARCH_GFX942 else inst_buffer_store_t(ctrl.vector_write_out * data_byte)
 
         s_out_offset_itr = sym_t(s_tmp6(0))
         # s_thread_m_stride = sym_t(s_tmp4(1))


### PR DESCRIPTION
Use gcnArchName as gcnArch is removed from Rocm6.0. Also add gfx942 and fix BFloat16.