### PR TITLE
Merge from fork to ROCm MISA develop branch

### DIFF
--- a/config/igemm_fwd_gtc_gfx942_nhwc_bf16.config
+++ b/config/igemm_fwd_gtc_gfx942_nhwc_bf16.config
@@ -91,55 +91,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 256x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 256x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 256x128x16
@@ -229,55 +181,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 256x128x16
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 2, 1, 128]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 2, 1, 128]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 256x128x16
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 2, 1, 128]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 2, 1, 128]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #########################################################################################
@@ -368,55 +272,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 256x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 256x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 256x64x16
@@ -506,55 +362,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 256x64x16
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 64
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 256x64x16
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 64
-gemm_k_per_block         = 16
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 256x64x8, padded_c
@@ -668,55 +476,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 256x32x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 32
-gemm_k_per_block         = 32
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 8, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 256x32x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 32
-gemm_k_per_block         = 32
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 8, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 256x32x8, padded_c
@@ -830,55 +590,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 128x256x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 4, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 128x256x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 4, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #########################################################################################
@@ -969,55 +681,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 128x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 128x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 128x128x16, padded_c
@@ -1154,55 +818,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 128x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 128x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 128x64x32
@@ -1273,31 +889,6 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 128x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_pass_through    = 1
-tensor_a_thread_lengths  = [1,16, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 2, 4, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 
 #--------------------------- 128x64x32
@@ -1322,31 +913,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 128x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_pass_through    = 1
-tensor_a_thread_lengths  = [1,16, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 2, 4, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 128x64x16, padded_c
@@ -1460,55 +1026,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 128x32x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 32
-gemm_k_per_block         = 32
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 128x32x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 32
-gemm_k_per_block         = 32
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 4, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 128x32x16, padded_c
@@ -1622,55 +1140,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 64x256x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 4, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 64x256x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 4, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #########################################################################################
@@ -1761,55 +1231,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 64x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 64x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1, 8, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 64]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 64]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #########################################################################################
@@ -1900,55 +1322,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 64x64x64
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 64
-gemm_k_per_block         = 64
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 16
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 64x64x64
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 64
-gemm_k_per_block         = 64
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 16
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 64x64x16, padded_c
@@ -2062,55 +1436,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 64x32x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 32
-gemm_k_per_block         = 32
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 64x32x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 32
-gemm_k_per_block         = 32
-wave_tile_m              = 64
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 16
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 8, 2, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 1, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 64x32x16, padded_c
@@ -2224,55 +1550,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 32x256x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 8, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 32x256x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 8, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #########################################################################################
@@ -2363,55 +1641,7 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 32x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 4, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-#--------------------------- 32x128x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 4, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 8, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 4, 4, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 8, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #########################################################################################
@@ -2502,55 +1732,8 @@ direction                = "fwd"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-#--------------------------- 32x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 8, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 1
 
-#--------------------------- 32x64x32
-[igemm_fwd_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1, 8, 1, 1]       # ExCxNB0xNB1
-tensor_a_cluster_lengths = [1, 4, 1, 32]      # ExCxNB0xNB1
-tensor_b_thread_lengths  = [1, 8, 2, 1]       # ExCxK0xK1
-tensor_b_cluster_lengths = [1, 4, 1, 32]      # ExCxK0XK1
-direction                = "fwd"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
 
 


### PR DESCRIPTION
Remove fwd gfx942 bf16 configs with both vector_store and gemm_k_global_split are set because they are indirectly duplicated with configs that have gemm_k_global_split set, which will always enable vector_write (equivalent to set vector_store).