### PR TITLE
Consolidate wrw gfx942 bf16 configs

### DIFF
--- a/config/igemm_wrw_gtc_gfx942_nhwc_bf16.config
+++ b/config/igemm_wrw_gtc_gfx942_nhwc_bf16.config
@@ -67,29 +67,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -113,29 +90,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 256x128
@@ -224,52 +178,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -315,52 +223,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 2
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 128x256
@@ -449,52 +311,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 256
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -540,52 +356,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 256
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 2
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 128x128
@@ -674,52 +444,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -765,52 +489,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 256x64
@@ -861,29 +539,6 @@ gemm_k_global_split      = 1
 [igemm_wrw_gtc]
 gemm_m_per_block         = 256
 gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 64
 gemm_k_per_block         = 16
 wave_tile_m              = 32
 wave_step_m              = 1
@@ -901,7 +556,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 1
-vector_store             = 1
 gemm_k_global_split      = 1
 
 [igemm_wrw_gtc]
@@ -951,29 +605,6 @@ gemm_k_global_split      = 1
 [igemm_wrw_gtc]
 gemm_m_per_block         = 256
 gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 256
-gemm_n_per_block         = 64
 gemm_k_per_block         = 16
 wave_tile_m              = 32
 wave_step_m              = 1
@@ -991,7 +622,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 64x256
@@ -1080,52 +710,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 256
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  1]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -1171,52 +755,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 256
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  1]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 128x64
@@ -1283,29 +821,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -1329,29 +844,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 128
-gemm_n_per_block         = 64
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 64x128
@@ -1440,52 +932,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  1]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -1531,52 +977,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 128
-gemm_k_per_block         = 32
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 128
-gemm_k_per_block         = 16
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 2
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  1]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  2]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  4,  1, 64]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 256x32
@@ -1622,7 +1022,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 1
-vector_store             = 1
 gemm_k_global_split      = 1
 
 [igemm_wrw_gtc]
@@ -1667,7 +1066,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 32x256
@@ -1734,29 +1132,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1,  4,  1,  1]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -1782,29 +1157,6 @@ nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 1
 
-[igemm_wrw_gtc]
-gemm_m_per_block         = 32
-gemm_n_per_block         = 256
-gemm_k_per_block         = 32
-wave_tile_m              = 16
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 64
-wave_step_n              = 1
-wave_repeat_n            = 2
-wave_tile_k              = 4
-tensor_a_thread_lengths  = [1,  4,  1,  1]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  8]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1,  8,  1, 32]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
-gemm_k_global_split      = 1
-
 #--------------------------- 64x64
 # for padding cases
 [igemm_wrw_gtc]
@@ -1827,7 +1179,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 1
-vector_store             = 1
 gemm_k_global_split      = 1
 
 [igemm_wrw_gtc]
@@ -1850,7 +1201,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 1
-vector_store             = 1
 gemm_k_global_split      = 1
 
 # for general cases
@@ -1917,29 +1267,6 @@ direction                = "wrw"
 precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
-nxe                      = 1
-vector_store             = 1
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 64
-gemm_k_per_block         = 64
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1, 16,  1, 16]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1, 16,  1, 16]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
 nxe                      = 0
 gemm_k_global_split      = 0
 
@@ -1963,29 +1290,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-gemm_k_global_split      = 1
-
-[igemm_wrw_gtc]
-gemm_m_per_block         = 64
-gemm_n_per_block         = 64
-gemm_k_per_block         = 64
-wave_tile_m              = 32
-wave_step_m              = 1
-wave_repeat_m            = 1
-wave_tile_n              = 32
-wave_step_n              = 1
-wave_repeat_n            = 1
-wave_tile_k              = 8
-tensor_a_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xK
-tensor_a_cluster_lengths = [1, 16,  1, 16]      # 1xNBx1xK
-tensor_b_thread_lengths  = [1,  4,  1,  4]      # 1xNBx1xC
-tensor_b_cluster_lengths = [1, 16,  1, 16]      # 1xNBx1xEC
-direction                = "wrw"
-precision                = "bf16"
-tensor_layout            = 'nhwc'
-nxb                      = 0
-nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1
 
 #--------------------------- 64x32
@@ -2031,7 +1335,6 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 1
-vector_store             = 1
 gemm_k_global_split      = 1
 
 [igemm_wrw_gtc]
@@ -2076,5 +1379,4 @@ precision                = "bf16"
 tensor_layout            = 'nhwc'
 nxb                      = 0
 nxe                      = 0
-vector_store             = 1
 gemm_k_global_split      = 1


### PR DESCRIPTION
There are 38 configs with both vector_store and gemm_k_global_split set, 30 of them are indirectly duplicated with those setting gemm_k_global_split only, they are different only by kernel name and labels, so they are removed in this PR. And 8 of them are not duplicated and remove vector_store setting for these configs. In bf16, it will always enable vector_write which is equivalent to set vector_store in the config. 