### PR TITLE
Fix bf16 conversion

### DIFF
--- a/driver/igemm_bwd_gtc_driver.h
+++ b/driver/igemm_bwd_gtc_driver.h
@@ -487,7 +487,10 @@ public:
                 return false;
             }
 
-            if(tunable->precision == "fp16"){
+            if (tunable->precision == "fp32") {
+                // no additional checks;
+            }
+            else if (tunable->precision == "fp16" || tunable->precision == "bf16") {
                 // fp16 support vector writeout by default. check get_vector_write_out()
                 if(tunable->tensor_a_thread_lengths[1] == 1 && tunable->tensor_b_thread_lengths[3] == 1 && tunable->merge_e && !tunable->gemm_k_global_split){
                     ;   // only case that support every config
@@ -503,9 +506,8 @@ public:
                             return false;
                     }
                 }
-            }
-
-            if(tunable->precision == "int8"){
+            } 
+            else if(tunable->precision == "int8"){
                 // fp16 support vector writeout by default. check get_vector_write_out()
                 if(tunable->tensor_a_thread_lengths[1] == 1){
                     ;   // if both 1, c is also write out one by one
@@ -519,6 +521,9 @@ public:
                             return false;
                     }
                 }
+            }
+            else {
+                assert(0);
             }
         }
 

--- a/driver/igemm_fwd_gtc_driver.h
+++ b/driver/igemm_fwd_gtc_driver.h
@@ -466,7 +466,11 @@ public:
             if((nxe == 0) && !unit_conv){
                 return false;
             }
-            if(tunable->precision == "fp16"){
+
+            if (tunable->precision == "fp32") {
+                // no additional checks;
+            }
+            else if (tunable->precision == "fp16" || tunable->precision == "bf16") {
                 // fp16 support vector writeout by default. check get_vector_write_out()
                 if(tunable->tensor_a_thread_lengths[1] == 1 && tunable->tensor_b_thread_lengths[1] == 1){
                     ;   // if both 1, k is also write out one by one
@@ -482,8 +486,7 @@ public:
                     }
                 }
             }
-
-            if(tunable->precision == "int8"){
+            else if (tunable->precision == "int8") {
                 // fp16 support vector writeout by default. check get_vector_write_out()
                 if(tunable->tensor_a_thread_lengths[1] == 1 && tunable->tensor_b_thread_lengths[1] == 1){
                     ;   // if both 1, k is also write out one by one
@@ -497,6 +500,9 @@ public:
                             return false;
                     }
                 }
+            }
+            else {
+                assert(0);
             }
         }else if(tunable->tensor_layout.compare(0, 5, "nchwc") == 0){
             auto tunable_wei_layout = tunable->tensor_layout.substr(6);

--- a/python/codegen/instruction.py
+++ b/python/codegen/instruction.py
@@ -82,7 +82,7 @@ class inst_mt_operand_t(object):
     def __call__(self):
         def expr_operand(opr):
             if type(self.operand) is str:
-                if re.search('[vs]\d+', self.operand) != None:
+                if re.search(r"[vs]\d+", self.operand) != None:
                     return self.operand
                 elif self.operand[0] == 's' or (self.operand[0:2] == r'\s'):
                     return f's[{self.operand}]'
@@ -161,7 +161,7 @@ class inst_v_cndmask_b32_t(inst_base_t):
         inst_base_t.__init__(self, INST_ENCODING_VOPC)
     def __call__(self, dst, src0, src1):
         if mc_get_current().arch_config.arch < 1000:
-            return 'v_cndmask_b32 {}, {}, {} vcc'.format(mt_opr(dst), mt_opr(src0), mt_opr(src1))
+            return 'v_cndmask_b32 {}, {}, {}, vcc'.format(mt_opr(dst), mt_opr(src0), mt_opr(src1))
         else:
             return 'v_cndmask_b32 {}, {}, {}'.format(mt_opr(dst), mt_opr(src0), mt_opr(src1))
 v_cndmask_b32 = inst_v_cndmask_b32_t()

--- a/python/igemm/igemm_bwd_gtc_nhwc.py
+++ b/python/igemm/igemm_bwd_gtc_nhwc.py
@@ -1209,7 +1209,7 @@ class igemm_bwd_gtc_nhwc_t(mc_base_t):
                         #num_v_wei_flag, num_v_pack_k_tmp = possible_assign_tmp(tb_nc_per_thread, tb_num_pack_k_tmp)
                         #self.v_wei_flag             = sym_t("v_wei_flag"        ,num_v_wei_flag)
                         #self.v_pack_k_tmp           = sym_t("v_pack_k_tmp"      ,num_v_pack_k_tmp)
-                        self.v_pack_k_tmp           = sym_t("v_pack_k_tmp"      ,vseq(tb_num_pack_k_tmp))
+                        self.v_pack_k_tmp           = sym_t("v_pack_k_tmp"      ,vseq(tb_num_pack_k_tmp,2))
                         self.v_wei_flag             = sym_t("v_wei_flag"        ,vseq(tb_nc_per_thread))
 
                 else:
@@ -1574,24 +1574,22 @@ class igemm_bwd_gtc_nhwc_t(mc_base_t):
                             for i_pk in range(packed_k_dword):
                                 idx_0 = 2 * i_pk * dwords_per_c + i_c // 2
                                 idx_1 = 2 * i_pk * dwords_per_c + i_c // 2 + dwords_per_c
+                                m_pack = macro_packhi_b32_t(self.mc) if i_c % 2 else macro_packlo_b32_t(self.mc)
+
                                 if self.outer.use_bf16_1k_in_fp16():
                                     src0_sel = '' if i_c % 2 == 0 else ' src0_sel:WORD_1'
                                     fp16_alt_impl_pds = self.outer.get_predefine_for_bf16_1k_in_fp16()
                                     self._emit(f'.if {fp16_alt_impl_pds} == 1')
                                     self._emit(f"v_cvt_f32_f16 v[{self.v_tmp2(0)}], v[{self.v_src(idx_0)}]{src0_sel}")
                                     self._emit(f"v_cvt_f32_f16 v[{self.v_tmp2(1)}], v[{self.v_src(idx_1)}]{src0_sel}")
-                                    self._emit(f"v_pack_b32_f16 v[{self.v_pack_k_tmp(i_pk)}], v[{self.v_tmp2(0)}], v[{self.v_tmp2(1)}]  op_sel:[1, 1]")
+                                    self._emit(macro_packhi_b32_t(self.v_pack_k_tmp(i_pk), self.v_tmp2(0), self.v_tmp2(1)))
                                     self._emit(f'.else')
-                                    op_sel = '' if i_c % 2 == 0 else ' op_sel:[1, 1]'
-                                    self._emit(f"v_pack_b32_f16 v[{self.v_pack_k_tmp(i_pk)}], v[{self.v_src(idx_0)}], v[{self.v_src(idx_1)}]{op_sel}")
+                                    self._emit(m_pack(self.v_pack_k_tmp(i_pk), self.v_src(idx_0), self.v_src(idx_1)))
                                     self._emit(f'.endif')
                                 else:
-                                    op_sel = '' if i_c % 2 == 0 else ' op_sel:[1, 1]'
-                                    # print(f"i_pk:{i_pk}, i_c:{i_c}, idx_0:{idx_0}, idx_1:{idx_1}")
-                                    self._emit(f"v_pack_b32_f16 v[{self.v_pack_k_tmp(i_pk)}], v[{self.v_src(idx_0)}], v[{self.v_src(idx_1)}]{op_sel}")
+                                    self._emit(m_pack(self.v_pack_k_tmp(i_pk), self.v_src(idx_0), self.v_src(idx_1)))
                             self._emit(ds_write(self.v_sst_os(), self.v_pack_k_tmp(), i_c * stride_dc))
                             self.issue_cnt = self.issue_cnt + ds_write.get_issues(i_c * stride_dc)
-
                     return
                 if tb_c1 == 1:
                     assert ta_k % tb_k == 0, "currently only need tb_k smaller than ta_k, other wise need add support for split k_pack"
@@ -2332,7 +2330,7 @@ class igemm_bwd_gtc_nhwc_t(mc_base_t):
                 self._emit(f"s_add_u32 s[{s.s_tmp()}], s[{s.s_tmp()}], s[{s.s_dtile_ix()}]")
             self._emit(f"v_add_lshl_u32 v[{v.v_wei_os()}], v[{v.v_tmp(4)}], v[{v.v_tmp(5)}], {igemm_log2(data_byte)}")
             if self.tunable.nxe != 0:
-                self._emit(f"s_lshl_b32 s[{s.s_tmp(1)}] s[{s.s_c()}], {igemm_log2(data_byte)}")
+                self._emit(f"s_lshl_b32 s[{s.s_tmp(1)}], s[{s.s_c()}], {igemm_log2(data_byte)}")
 
             if self.tunable.merge_e == 1:
                 self._emit(f"v_mul_u32_u24 v[{v.v_tmp(0)}], s[{s.s_dtile_x()}], v[{v.v_wei_dslice_ix_itr()}]")

--- a/python/operations/coalescing_store.py
+++ b/python/operations/coalescing_store.py
@@ -881,7 +881,7 @@ class igemm_coalescing_store_xdlops_t(mc_base_t):
             then, consider that introduced by granularity
             '''
             self._emit(f"v_lshrrev_b32 v[{v_tmp4}], {utility_log2(ctrl.cxm.lanegroup_m_per_thread())}, v[{v_gemm_im}]")
-            self._emit(f"v_and_b32 v[{v_tmp4}],  {ctrl.cxm.lanegroup_m_per_cluster() - 1} v[{v_tmp4}]   ; thread id of lanegroup_m_per_cluster")
+            self._emit(f"v_and_b32 v[{v_tmp4}],  {ctrl.cxm.lanegroup_m_per_cluster() - 1}, v[{v_tmp4}]   ; thread id of lanegroup_m_per_cluster")
             self._emit(f"v_lshlrev_b32 v[{v_co_sst}], {utility_log2(ctrl.cxm.lanegroup_m_per_thread())}, v[{v_tmp4}]")
 
             if ctrl.cxm.block_m_per_lanegroup() != 1:
@@ -1277,13 +1277,14 @@ class igemm_coalescing_store_xdlops_t(mc_base_t):
                                 self._emit(f"v_pack_b32_f16 v[{v_c(vgpr_index + 0)}], v[{v_c(vgpr_index + 0)}], v[{v_c(vgpr_index + 1)}]")
                                 self._emit(f"v_pack_b32_f16 v[{v_c(vgpr_index + 1)}], v[{v_c(vgpr_index + 2)}], v[{v_c(vgpr_index + 3)}]")
                         if ctrl.precision == 'bf16':
+                            macro_packhi = macro_packhi_b32_t(self.mc)
                             if ctrl.vector_write_out == 1:
                                 if not ctrl.accvgpr_unified:
-                                    self._emit(f"v_pack_b32_f16 v[{v_c(vgpr_index + 0)}], v[{v_c(vgpr_index + 0)}], v[{v_c(vgpr_index + 1)}] op_sel:[1,1]")
-                                    self._emit(f"v_pack_b32_f16 v[{v_c(vgpr_index + 1)}], v[{v_c(vgpr_index + 2)}], v[{v_c(vgpr_index + 3)}] op_sel:[1,1]")
+                                    self._emit(macro_packhi(v_c(vgpr_index + 0), v_c(vgpr_index + 0), v_c(vgpr_index + 1)))
+                                    self._emit(macro_packhi(v_c(vgpr_index + 1), v_c(vgpr_index + 2), v_c(vgpr_index + 3)))
                                 else:
-                                    self._emit(f"v_pack_b32_f16 v[{v_c(vgpr_index + 0)}], v[{a_c(agpr_index + 0)}], v[{a_c(agpr_index + 1)}] op_sel:[1,1]") ; agpr_consume_list.append(agpr_index + 0) ; agpr_consume_list.append(agpr_index + 1)
-                                    self._emit(f"v_pack_b32_f16 v[{v_c(vgpr_index + 1)}], v[{a_c(agpr_index + 2)}], v[{a_c(agpr_index + 3)}] op_sel:[1,1]") ; agpr_consume_list.append(agpr_index + 2) ; agpr_consume_list.append(agpr_index + 3)
+                                    self._emit(macro_packhi(v_c(vgpr_index + 0), a_c(agpr_index + 0), a_c(agpr_index + 1))) ; agpr_consume_list.append(agpr_index + 0) ; agpr_consume_list.append(agpr_index + 1)
+                                    self._emit(macro_packhi(v_c(vgpr_index + 1), a_c(agpr_index + 2), a_c(agpr_index + 3))) ; agpr_consume_list.append(agpr_index + 2) ; agpr_consume_list.append(agpr_index + 3)
                             else:
                                 if not ctrl.accvgpr_unified:
                                     self._emit(f"v_lshrrev_b32 v[{v_c(vgpr_index + 0)}], 16, v[{v_c(vgpr_index + 0)}]")

--- a/python/operations/mfma_main_loop.py
+++ b/python/operations/mfma_main_loop.py
@@ -228,7 +228,7 @@ class mfma_main_loop_t(mc_base_t):
         if mbb_p_clear == 1:
             # hack on v_clear_nc
             v_clear_nc_strs = mbb_gld_p[0].mc_inst(-1).inst_str
-            v_clear_nc_list = re.split('[,\s]+', v_clear_nc_strs)
+            v_clear_nc_list = re.split(r"[,\s]+", v_clear_nc_strs)
             assert len(v_clear_nc_list) == 3 and v_clear_nc_list[0] == '.v_clear_nc'
             num_gld_p = int(v_clear_nc_list[2]) # TODO: check number
             assert num_gld_p % (len(mbb_gld_p) - mbb_p_clear) == 0
@@ -475,7 +475,7 @@ class mfma_main_loop_t(mc_base_t):
                                         self._emit(f".if {ctrl.pass_through_bf16_1k_in_fp16_predefine} == 1")
                                         self._emit(f"v_cvt_f32_f16 v[{v_gld_p(i_pnum)}], v[{v_gld_p_gpf(i_pnum)}]")
                                         self._emit(f"v_cvt_f32_f16 v[{v_gld_p_gpf(i_pnum)}], v[{v_gld_p_gpf(i_pnum)}] src0_sel:WORD_1")
-                                        self._emit(f"v_pack_b32_f16 v[{v_gld_p(i_pnum)}], v[{v_gld_p(i_pnum)}], v[{v_gld_p_gpf(i_pnum)}] op_sel:[1,1]")
+                                        self._emit(macro_packhi_b32_t(v_gld_p(i_pnum), v_gld_p(i_pnum), v_gld_p_gpf(i_pnum)))
                                         self._emit(f".else")
                                         self._emit(f"v_mov_b32 v[{v_gld_p(i_pnum)}], v[{v_gld_p_gpf(i_pnum)}]")
                                         self._emit(f".endif")

--- a/python/operations/utility.py
+++ b/python/operations/utility.py
@@ -27,6 +27,8 @@
 from ..codegen import *
 import math
 
+DBG_USE_PACK_F16_FOR_BF16 = 0
+
 class macro_int_div_vv_t(macro_base_t):
     '''
     integer divide to compute `v_q = v_n / v_d`, v_q, v_n, v_d all vgpr
@@ -538,6 +540,41 @@ class gpr_sequencer_t(object):
     def get(self):
         return self.cnt
 
+class macro_packlo_b32_t(macro_base_t):
+    def __init__(self, mc):
+        macro_base_t.__init__(self, mc, True)
+        self.declare_arg("v_dst")
+        self.declare_arg("v_a")
+        self.declare_arg("v_b")
+
+    def name(self):
+        return '.v_packlo_b32'
+
+    def expr(self):
+        if DBG_USE_PACK_F16_FOR_BF16:
+            self._emit(f"v_pack_b32_f16 v[{self.v_dst()}], v[{self.v_a()}], v[{self.v_b()}]")
+        else:
+            self._emit(f"v_lshlrev_b32  v[{self.v_dst()}], 16, v[{self.v_a()}]")
+            self._emit(f"v_alignbit_b32 v[{self.v_dst()}], v[{self.v_b()}], v[{self.v_dst()}], 16")
+
+class macro_packhi_b32_t(macro_base_t):
+    def __init__(self, mc):
+        macro_base_t.__init__(self, mc, True)
+        self.declare_arg("v_dst")
+        self.declare_arg("v_a")
+        self.declare_arg("v_b")
+
+    def name(self):
+        return '.v_packhi_b32'
+
+    def expr(self):
+        if DBG_USE_PACK_F16_FOR_BF16:
+            self._emit(f"v_pack_b32_f16 v[{self.v_dst()}], v[{self.v_a()}], v[{self.v_b()}] op_sel:[1, 1]")
+        else:
+            self._emit(f"v_lshrrev_b32  v[{self.v_dst()}], 16, v[{self.v_b()}]")
+            self._emit(f"v_alignbit_b32 v[{self.v_dst()}], v[{self.v_dst()}], v[{self.v_a()}], 16")
+
+
 class macro_packed_fp16_to_bf16_t(macro_base_t):
     def __init__(self, mc, **options):
         macro_base_t.__init__(self, mc, True)
@@ -554,7 +591,7 @@ class macro_packed_fp16_to_bf16_t(macro_base_t):
         for i in range(num_vgpr):
             self._emit(f"v_cvt_f32_f16 v[{self.v_tmp()}], v[{self.v_packed_f16(i)}]")
             self._emit(f"v_cvt_f32_f16 v[{self.v_packed_f16(i)}], v[{self.v_packed_f16(i)}] src0_sel:WORD_1")
-            self._emit(f"v_pack_b32_f16 v[{self.v_packed_f16(i)}], v[{self.v_tmp()}], v[{self.v_packed_f16(i)}] op_sel:[1,1]")
+            self._emit(macro_packhi_b32_t(self.v_packed_f16(i), self.v_tmp(), self.v_packed_f16(i)))
 
 def utility_list_to_string(arr):
     assert type(arr) is list


### PR DESCRIPTION
Original code used v_pack_b32_f16 for converting (implicitly by truncation) and packing fp32 values into bf16. However, the instruction interprets data as fp16. Values with big exponent would be converted to inf or nan values.. Also, depending on a denorm mode it could flush normalized bf16 values to zero. The truncation in original code works as round towards zero. This PR preserves such rounding.