### PR TITLE
Fix bwd applicability

### DIFF
--- a/driver/igemm_bwd_gtc_driver.h
+++ b/driver/igemm_bwd_gtc_driver.h
@@ -476,6 +476,14 @@ public:
                 return false;
             }
         } else if (tunable->tensor_layout == "nhwc"){
+            // limitation for loading filter using multielement instructions
+            int tb_c1 = tunable->tensor_b_thread_lengths[3];
+            int data_byte = utility_string_to_data_byte(tunable->precision);
+            int vector_d1 = utility_gcd(tb_c1, 4 * (4 / data_byte));
+            if ((c / group) % vector_d1 != 0)
+                return false;
+
+
             if(tunable->tensor_a_thread_lengths[1] == 1){
                 ;   // if output k 1, indicate padded k support
             }

--- a/python/operations/global_memory.py
+++ b/python/operations/global_memory.py
@@ -194,7 +194,7 @@ def inst_buffer_atomic_add_emit_with_macro(mc):
         mc.emit(f'{label_cas_loop_start}:')
         mc.emit(f'    buffer_load_dword v[v_tmp+2], \\addr, \\base, \\other sc1') # should bypass L1
         mc.emit(f'    s_waitcnt vmcnt(0)')
-        mc.emit(f'    v_mov_b32 v[v_tmp+3] v[v_tmp+2]')
+        mc.emit(f'    v_mov_b32 v[v_tmp+3], v[v_tmp+2]')
         mc.emit(f'    {get_add_inst(inst)} v[v_tmp+2], \\data, v[v_tmp+3]')
         ########      tmp = dst, dst = v_tmp+3 == tmp ? v_tmp+2 : v_tmp, v_tmp+2 = v_tmp(return value)
         mc.emit(f'    buffer_atomic_cmpswap v[v_tmp+2:v_tmp+3], \\addr, \\base, \\other sc0')


### PR DESCRIPTION
Original code might use multielement instructions in some configurations for filter loads, but relevant checks for divisibility were missed. This PR adds the check for C dimension (KHW dims should be covered in shader with per lane masking).